### PR TITLE
Add arguments to create_metadata to *disable* download or processing

### DIFF
--- a/mgw/settings.py
+++ b/mgw/settings.py
@@ -101,7 +101,7 @@ DATA_DIR = env("DATA_DIR")
 
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases
-DB_DIR = env("DB_DIR")
+DB_DIR = Path(env("DB_DIR"))
 DB_DIR.mkdir(parents=True, exist_ok=True)
 
 DATABASES = {

--- a/mgw_api/management/commands/create_metadata.py
+++ b/mgw_api/management/commands/create_metadata.py
@@ -33,6 +33,19 @@ except:
 
 
 class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--no-download",
+            action="store_true",
+            help="Do not download latest SRA metadata from S3",
+        )
+        parser.add_argument(
+            "--no-process",
+            action="store_true",
+            help="Do not process the downloaded SRA data and load it into the mongodb",
+        )
+
+
     def handle(self, *args, **kwargs):
         now = datetime.now()
         dt = now.strftime("%d.%m.%Y %H:%M:%S")
@@ -40,7 +53,8 @@ class Command(BaseCommand):
         try:
             self.clean_log()
             self.write_log(f"Starting metadata update!")
-            re_download, re_process = False, True
+            re_download = not kwargs["no_download"]
+            re_process = not kwargs["no_process"]
             database = "SRA"
             dir_paths = self.handle_dirs(database, ["parquet"])
             column_list, jattr_list = self.get_filter_data()

--- a/mgw_api/management/commands/runserver.py
+++ b/mgw_api/management/commands/runserver.py
@@ -22,7 +22,9 @@ class Command(StaticRunServerCommand):
             init_flag = os.path.join(settings.DATA_DIR, "SRA", "metadata", "initial_setup.txt")
             if not os.path.exists(init_flag):
                 print("Creating initial metadata...")
-                call_command('create_metadata')
+                # Skip downloading to restore the original behaviour we had
+                # before arguments were added to create_metadata
+                call_command('create_metadata', '--no-download')
 
         # Stop cron jobs and mail server on exit
         signal.signal(signal.SIGINT, self.stop_services)


### PR DESCRIPTION
By default, both downloading of new data from S3 and processing of that data is enabled. Two options were added to allow you to disable each of these:
```
manage.py create_metadata --no-download --no-process
```
The development `runserver` disables downloading to match the existing behavior.