### PR TITLE
Limit the number of search results in the result table to 100

### DIFF
--- a/mgw/settings.py
+++ b/mgw/settings.py
@@ -55,12 +55,16 @@ env = environ.Env(
     LDAP_SEARCH_ROOT=(str, None),
     LDAP_ATTR_USERNAME=(str, None),
     LDAP_ATTR_EMAIL=(str, None),
+    MAX_SEARCH_RESULTS=(int, 100),
 )
 
 environ.Env.read_env(BASE_DIR / "vars.env")
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
+
+# The maximum number of search results to provide
+MAX_SEARCH_RESULTS = env("MAX_SEARCH_RESULTS")
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = env("SECRET_KEY")

--- a/mgw_api/functions.py
+++ b/mgw_api/functions.py
@@ -14,12 +14,17 @@ from mgw.settings import LOGGER
 from .models import Fasta
 
 
-def get_table_data(result):
+def get_table_data(result, max_rows=None):
     table_data = []
     with open(result.file.path, newline="") as csvfile:
         reader = csv.reader(csvfile)
+        # The first row is a header, we don't count it
+        n_rows = -1
         for row in reader:
             table_data.append(row)
+            n_rows += 1
+            if max_rows and n_rows >= max_rows:
+                break
     return table_data[0], table_data[1:]
 
 

--- a/mgw_api/urls.py
+++ b/mgw_api/urls.py
@@ -16,7 +16,7 @@ urlpatterns = [
         "process_signature/<int:pk>/", views.process_signature, name="process_signature"
     ),
     path("delete_signature/<int:pk>/", views.delete_signature, name="delete_signature"),
-    path("settings/", views.settings, name="settings"),
+    path("settings/", views.sourmash_settings, name="settings"),
     path("results/", views.list_result, name="list_result"),
     path("result/<int:pk>/", views.result_table, name="result_table"),
     path(

--- a/mgw_api/views.py
+++ b/mgw_api/views.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import threading
 
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.decorators import login_required
@@ -220,7 +221,7 @@ def process_signature(request, pk):
 
 
 @login_required
-def settings(request):
+def sourmash_settings(request):
     sourmash_settings, created = Settings.objects.get_or_create(user=request.user)
     if request.method == "POST":
         settings_form = SettingsForm(request.POST, instance=sourmash_settings)
@@ -341,7 +342,7 @@ def result_table(request, pk):
     else:
         ## handle result table
         result = get_object_or_404(Result, pk=pk, user=request.user)
-        headers, rows = get_table_data(result)
+        headers, rows = get_table_data(result, max_rows=settings.MAX_SEARCH_RESULTS)
         headers, rows = get_metadata(headers, rows)
 
         headers = [h.replace("_", " ") for h in headers]

--- a/vars.env.example
+++ b/vars.env.example
@@ -20,3 +20,6 @@ LDAP_BIND_PASSWORD=
 LDAP_SEARCH_ROOT=
 LDAP_ATTR_USERNAME=user
 LDAP_ATTR_EMAIL=mail
+# The maximum number of search results to show in the results table. Doesn't
+# limit the number of results in the downloaded result files.
+#MAX_SEARCH_RESULTS=100


### PR DESCRIPTION
Searches can yield 1000s of results or even far more (the database is huge). That many results will cause problems in the results page, and are probably not very interesting for the users. Add a limit to the number of results that is shown in the results table (currently 100, can be set in vars.env). This currently does not limit the size of the results file that can be downloaded.
