### PR TITLE
Update docs. Switch from aws s3 cp to aws s3 sync. Closes #109

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,11 +1,23 @@
 # Updates
 
+## Summary of important files and directories
+
+All subfolders of `backend-data/SRA/metagenomes`:
+
+- `failed/`: ?
+- `index/`: Branchwater indexes
+- `lists/`: lists of SRA IDs explaining what is contained in the indexes generated from data received from Titus et al. Not used in the future.
+- `manifest.pcl`: a list of all SRA indexes that are stored in all indexes (the union of manifests/*.pcl file contents)
+- `manifests/`: list of SRA indexes that are stored in each matching index file (in index/)
+- `signatures/`: signatures downloaded from wort that have been indexed
+- `updates/`: signatures downloaded from wort but not yet indexed
+
 ## Initial setup
 
 Before any update on the index, the following command has to be run once from inside the code directory. Before running the command, all `sig-sra-<0-9>.txt` files have to be moved inside the `data/SRA/metagenomes/lists/` directory. These are then used inside the `create_manifest.py` command to generate the main manifest and all individual index manifests.
 
 ```bash
-./scripts/dev-manage.sh create_manifest
+./scripts/dev-manage.sh create_manifests
 ```
 
 This will create the initial `manifest.pcl` and all individual index manifest files available in `data/SRA/metagenomes/manifests/`.


### PR DESCRIPTION
Fixed a typo in the docs for setting up wort updates. Also switched aws command to use sync instead of cp. This will be way faster when the command is run multiple times in a day (doing dev perhaps), but might not be faster in general because I think that all files are regenerated every day. Need to see. It shouldn't be slower (I hope).