### PR TITLE
Fix crash in create_watch() email generation

### DIFF
--- a/mgw/settings.py
+++ b/mgw/settings.py
@@ -27,7 +27,7 @@ env = environ.Env(
     DEBUG=(bool, False),
     SECRET_KEY=str,
     ALLOWED_HOSTS=(str, None),
-    HOSTNAME=(str, None),
+    MGW_URL=(str, None),
     CSRF_TRUSTED_ORIGINS=(str, None),
     TIME_ZONE=(str, "Europe/Berlin"),
     DATA_DIR=(Path, BASE_DIR / ".." / "mgw-data"),
@@ -62,7 +62,7 @@ env = environ.Env(
 environ.Env.read_env(BASE_DIR / "vars.env")
 
 # The hostname to use for links (e.g. https://mgwatch.example.com)
-HOSTNAME = env("HOSTNAME")
+MGW_URL = env("MGW_URL")
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/

--- a/vars.env.example
+++ b/vars.env.example
@@ -2,6 +2,7 @@ DEBUG=False
 SECRET_KEY="django-insecure-em&y0o^!@ha-kujz4qch11-a*qy8t3peg8@%+=(_+-bnwzr2%z"
 ALLOWED_HOSTS=localhost
 CSRF_TRUSTED_ORIGINS="http://localhost"
+MGW_URL="http://localhost"
 TIME_ZONE="Europe/Berlin"
 # This is a path inside the backend docker container
 DATA_DIR="/data"


### PR DESCRIPTION
Use a separate MGW_URL setting to generate urls for the link to new results. The previous code tried to use results, which seems to not be available in management commands.