### PR TITLE
Temporarily disable the metadata filter that only includes librarysource == METAGENOMIC samples

### DIFF
--- a/mgw_api/management/commands/create_metadata.py
+++ b/mgw_api/management/commands/create_metadata.py
@@ -276,8 +276,8 @@ class Command(BaseCommand):
                 f"https://www.ncbi.nlm.nih.gov/sra/{meta_dict.get('acc', '')}"
             )
             meta_dict["_id"] = meta_dict["acc"]
-            if meta_dict["librarysource"] == "METAGENOMIC":
-                new_attr.append(meta_dict)
+            # if meta_dict["librarysource"] == "METAGENOMIC":
+            new_attr.append(meta_dict)
         res_list.append(new_attr)
 
     def process_value(self, v):


### PR DESCRIPTION
We disable this because our index has more than just METAGENOMIC samples, leading to empty rows in our results table. Find a more restrictive filter so that we don't have to load the entire SRA database worth of metadata every time we do an update.
