### PR TITLE
When syncing metadata from S3, delete old files that are no longer present at the source

### DIFF
--- a/mgw_api/management/commands/create_metadata.py
+++ b/mgw_api/management/commands/create_metadata.py
@@ -160,6 +160,7 @@ class Command(BaseCommand):
             "s3://sra-pub-metadata-us-east-1/sra/metadata/",
             parquet_dir,
             "--no-sign-request",
+            "--delete",
         ]
         result = subprocess.Popen(
             command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True


### PR DESCRIPTION
This is a change from when we were using cp. With copy, we manually deleted the local files first. Using sync we don't do that, because if the files haven't been updated at the source then we can skip the download, but it does mean that we need to use --delete to delete the previous download's files in the case that the files have been updated.
