### PR TITLE
Stop pre-computing links, generate them on the fly when rendering the results table. Fix date formatting of releasedate, fix lat lon linking to nothing

### DIFF
--- a/mgw_api/functions.py
+++ b/mgw_api/functions.py
@@ -151,10 +151,10 @@ def prettify_column_names(df):
 def add_sra_metadata(branchwater_results):
     branchwater_results.rename_axis("sra_accession", inplace=True)
     sra_columns = [
-        "sra_link",
+        "sra_accession",
+        "sra_bioproject",
+        "sra_biosample",
         "assay_type",
-        "bioproject",
-        "biosample_link",
         "collection_date_sam",
         "geo_loc_name_country_calc",
         "lat_lon",
@@ -165,6 +165,7 @@ def add_sra_metadata(branchwater_results):
     sra_accessions = branchwater_results.index.to_list()
     sra_metadata = get_sra_fields(sra_accessions, sra_columns)
     results_with_metadata = branchwater_results.join(sra_metadata, on="sra_accession")
+    results_with_metadata = results_with_metadata.reset_index(drop=True)
     LOGGER.info(f"branchwater_results: {branchwater_results}")
     LOGGER.info(f"sra_metadata: {sra_metadata}")
     LOGGER.info(f"joined: {results_with_metadata}")
@@ -173,10 +174,10 @@ def add_sra_metadata(branchwater_results):
 
 def reorder_result_columns_sra(df):
     output_ordering = [
-        "sra_link",
+        "sra_accession",
+        "sra_bioproject",
+        "sra_biosample",
         "assay_type",
-        "bioproject",
-        "biosample_link",
         "query_containment_ani",
         "collection_date_sam",
         "containment",
@@ -214,7 +215,6 @@ def get_sra_fields(sra_accessions, fields):
     pd.set_option("display.max_columns", None)
     LOGGER.info(f"get_sra_fields: {sra_metadata}")
     sra_metadata.set_index("_id", inplace=True)
-    sra_metadata.rename_axis("sra_accession", inplace=True)
     missing_columns = set(fields) - set(sra_metadata.columns)
     if len(missing_columns) > 0:
         LOGGER.warning(
@@ -243,5 +243,4 @@ def get_results_with_metadata(result, max_results=None):
     results_with_metadata = add_sra_metadata(branchwater_results)
     results_with_metadata = reorder_result_columns_sra(results_with_metadata)
     results_with_metadata = prettify_column_names(results_with_metadata)
-    results_with_metadata = results_with_metadata.reset_index()
     return results_with_metadata

--- a/mgw_api/management/commands/create_metadata.py
+++ b/mgw_api/management/commands/create_metadata.py
@@ -157,27 +157,11 @@ class Command(BaseCommand):
                 .unnest("jattr_decoded")  # Unnest to split struct into separate columns
                 .with_columns(
                     [
-                        pl.when(pl.col("acc").is_not_null())
-                        .then(
-                            pl.format(
-                                "https://www.ncbi.nlm.nih.gov/sra/{}", pl.col("acc")
-                            )
-                        )
-                        .otherwise(None)
-                        .alias("sra_link"),
-                        pl.when(pl.col("biosample").is_not_null())
-                        .then(
-                            pl.format(
-                                "https://www.ncbi.nlm.nih.gov/biosample/{}",
-                                pl.col("biosample"),
-                            )
-                        )
-                        .otherwise(None)
-                        .alias("biosample_link"),
+                        (pl.col("acc").alias("_id")),
+                        (pl.col("acc").alias("sra_accession")),
+                        (pl.col("biosample").alias("sra_biosample")),
+                        (pl.col("bioproject").alias("sra_bioproject")),
                     ]
-                )
-                .with_columns(
-                    [pl.col("acc").alias("_id")]
                 )  # assign acc to the special mongodb _id field
             )
 

--- a/mgw_api/templates/mgw_api/result_table.html
+++ b/mgw_api/templates/mgw_api/result_table.html
@@ -35,15 +35,21 @@
                             <tr>
                                 {% for cell, header in row|zip_lists:headers %}
                                     <td>
-                                        {% if header == "sra link" or header == "biosample link" %}
-                                            <a href="{{ cell }}" target="_blank">{{ cell|last_part_of_url }}</a>
-                                        {% elif header == "containment" or header == "query containment ani" %}
+                                        {% if header == "containment" or header == "query containment ani" %}
                                             {{ cell|floatformat:4 }}
                                         {% elif header == "lat lon" %}
-                                            {% if cell != "None" %}
+                                            {% if cell is not None %}
                                                 <a href="https://www.openstreetmap.org/#map=12/{{ cell|lat_lon_for_osm }}">view map</a>
                                             {% endif %}
-                                        {% elif cell == "None" %}
+                                        {% elif header == "sra accession" and cell is not None %}
+                                            <a href="https://www.ncbi.nlm.nih.gov/sra/{{ cell|escape }}">{{ cell }}</a>
+                                        {% elif header == "sra biosample" and cell is not None %}
+                                            <a href="https://www.ncbi.nlm.nih.gov/biosample/{{ cell|escape }}">{{ cell }}</a>
+                                        {% elif header == "sra bioproject" and cell is not None %}
+                                            <a href="https://www.ncbi.nlm.nih.gov/bioproject/{{ cell|escape }}">{{ cell }}</a>
+                                        {% elif header == "releasedate" and cell is not None %}
+                                            {{ cell|date:"Y-m-d" }}
+                                        {% elif cell is None %}
                                         {% else %}
                                             {{ cell }}
                                         {% endif %}
@@ -71,7 +77,7 @@
     };
     $(document).ready( function () {
         $('#results').DataTable( {
-            order: [[7, 'desc']],
+            order: [[6, 'desc']],
             layout: {
                 topStart: 'info',
                 topEnd: 'search',


### PR DESCRIPTION
Instead of having separate columns for the SRA accession, biosample and
bioproject + their links into the SRA site, we linkify them when generating the
table. This does mean that the downloaded tsv will not have links. I think that
is okay.

I also corrected the formatting of release dates, and fixed the issue where lat
long was displaying a link even when there is no lat long information.
