### PR TITLE
Change dev ports, use docker compose watch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,13 +6,14 @@ repos:
         args: ['--maxkb=5120']
       - id: check-shebang-scripts-are-executable
       - id: check-yaml
+        args: [--unsafe]
       - id: check-json
       - id: end-of-file-fixer
         types_or: [python, markdown, shell]
       - id: trailing-whitespace
         types_or: [python, markdown, shell]
   - repo: https://github.com/google/yamlfmt
-    rev: v0.14.0
+    rev: v0.20.0
     hooks:
       - id: yamlfmt
   - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -35,3 +36,12 @@ repos:
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
+  #- repo: https://github.com/scop/pre-commit-shfmt
+  #  rev: v3.12.0-2
+  #  hooks:
+  #    - id: shfmt # prebuilt upstream executable
+  #      args: [--indent=4, --language-dialect=bash]
+  - repo: https://github.com/openstack/bashate
+    rev: 2.1.1
+    hooks:
+      - id: bashate

--- a/compose-dev.yml
+++ b/compose-dev.yml
@@ -5,16 +5,35 @@
 # rebuild the container.
 services:
   mgwatch-backend:
-    volumes:
-      # Overlay the code directory so that you can directly edit code and not
-      # need to rebuild the docker container. It will be live-reloaded by the
-      # django runserver dev server started below.
-      - .:/code
     ports:
       # To access the backend directly, normally can use localhost:8000 via the
       # nginx proxy
-      - "9080:9080"
+      - "9081:9080"
     command: ["conda run --no-capture-output -n mgw ./manage.py collectstatic --no-input && conda run --no-capture-output -n mgw ./manage.py runserver 0.0.0.0:9080"]
+    build: .
+    develop:
+      watch:
+        - action: sync
+          path: ./mgw
+          target: /code/mgw
+          initial_sync: true
+        - action: sync
+          path: ./mgw_api
+          target: /code/mgw_api
+          initial_sync: true
+        - action: sync
+          path: ./templates
+          target: /code/templates
+          initial_sync: true
+        - action: sync
+          path: ./mgw
+          target: /code/mgw
+          initial_sync: true
+        - action: rebuild
+          path: mgw.yaml
   mgwatch-mongodb:
     ports:
-      - "27017:27017"
+      - "27018:27017"
+  mgwatch-proxy:
+    ports: !override
+      - 8889:8000

--- a/mgw-prod.sh
+++ b/mgw-prod.sh
@@ -10,20 +10,20 @@ MIGRATE=1
 SHOW_LOGS=1
 
 while getopts "bcmlh" opt; do
-  case $opt in
+    case $opt in
     b) BUILD_CONTAINER=0 ;;
     c) CREATE_MIGRATIONS=0 ;;
     m) MIGRATE=0 ;;
     l) SHOW_LOGS=0 ;;
     h)
-      echo "./mgw-prod.sh [-b] [-c] [-m]"
-      echo " -b     build backend docker container"
-      echo " -c     create (=make) migrations"
-      echo " -m     migrate"
-      echo " -l     follow logs when everything has started"
-      exit 0
-      ;;
-  esac
+        echo "./mgw-prod.sh [-b] [-c] [-m]"
+        echo " -b     build backend docker container"
+        echo " -c     create (=make) migrations"
+        echo " -m     migrate"
+        echo " -l     follow logs when everything has started"
+        exit 0
+        ;;
+    esac
 done
 
 ./scripts/dc-prod.sh down --remove-orphans

--- a/mgw.sh
+++ b/mgw.sh
@@ -11,22 +11,22 @@ SHOW_LOGS=1
 LOAD_DATA=1
 
 while getopts "bcmldh" opt; do
-  case $opt in
+    case $opt in
     b) BUILD_CONTAINER=0 ;;
     c) CREATE_MIGRATIONS=0 ;;
     m) MIGRATE=0 ;;
     l) SHOW_LOGS=0 ;;
     d) LOAD_DATA=0 ;;
     h)
-      echo "./mgw.sh [-b] [-c] [-m]"
-      echo " -b     build backend docker container"
-      echo " -c     create (=make) migrations"
-      echo " -m     migrate"
-      echo " -d     load test data and user accounts for development"
-      echo " -l     follow logs when everything has started"
-      exit 0
-      ;;
-  esac
+        echo "./mgw.sh [-b] [-c] [-m]"
+        echo " -b     build backend docker container"
+        echo " -c     create (=make) migrations"
+        echo " -m     migrate"
+        echo " -d     load test data and user accounts for development"
+        echo " -l     follow logs when everything has started"
+        exit 0
+        ;;
+    esac
 done
 
 ./scripts/dc-dev.sh down --remove-orphans
@@ -36,4 +36,5 @@ done
 [[ CREATE_MIGRATIONS -eq 0 ]] && ./scripts/dev-manage.sh makemigrations
 [[ MIGRATE -eq 0 ]] && ./scripts/dev-manage.sh migrate
 [[ LOAD_DATA -eq 0 ]] && ./scripts/dev-load-fixtures.sh
-[[ SHOW_LOGS -eq 0 ]] && ./scripts/dc-dev.sh logs -tf
+[[ SHOW_LOGS -eq 0 ]] && ./scripts/dc-dev.sh logs -tf &
+./scripts/dc-dev.sh watch --no-up


### PR DESCRIPTION
Instead of mounting a volume over top of our source code directory, we use the docker compose 'watch' functionality. This is better for several reasons, one of which is that changes to the conda environment file properly trigger a full container rebuild.

Also, I changed the ports used in development to avoid conflicts with another project. These should probably be set via a config file so people can use whatever is convenient for them, but I'll worry about that when the project has more developers.
