### PR TITLE
Make aiohttp session use the proxy settings from the environment

### DIFF
--- a/mgw_api/management/commands/create_downloads.py
+++ b/mgw_api/management/commands/create_downloads.py
@@ -307,7 +307,7 @@ class Command(BaseCommand):
 
     async def fetch_all(self, urls, target_dir, IDs_succ, IDs_fail, man_succ, man_fail):
         lock = asyncio.Lock()
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(trust_env=True) as session:
             tasks = [
                 self.fetch(
                     session,


### PR DESCRIPTION
Fixes the error:

```
Download exception for https://wort.sourmash.bio/v1/view/sra/SRR29161363: Cannot connect to host wort.sourmash.bio:443 ssl:default [Connect call failed ('150.230.176.118', 443)]
```
