### PR TITLE
Delete signatures after a full index batch is successfully built

### DIFF
--- a/mgw/settings.py
+++ b/mgw/settings.py
@@ -43,6 +43,7 @@ env = environ.Env(
     LOG_LEVEL=(str, "DEBUG"),
     INDEX_FROM_SCRATCH=(bool, False),
     INDEX_MAX_SIGNATURES=(int, 100000),
+    DELETE_INDEXED_SIGS=(bool, False),
     START_DATE=(str, "2024-03-15"),
     END_DATE=(str, "2024-03-15"),
     LIB_SOURCE=(list, []),
@@ -80,6 +81,7 @@ MONGO_URI = env("MONGO_URI")
 INDEX_FROM_SCRATCH = env("INDEX_FROM_SCRATCH")
 # number of signatures in each index
 INDEX_MAX_SIGNATURES = env("INDEX_MAX_SIGNATURES")
+DELETE_INDEXED_SIGS = env("DELETE_INDEXED_SIGS")
 INDEX_MIN_ITERATOR = env("INDEX_MIN_ITERATOR")
 # format: "yyyy-mm-dd" if START_DATE set to "auto", start and end will be set to today - 2 days; current index is on "2023-09-27"
 START_DATE = env("START_DATE")

--- a/mgw_api/management/commands/create_index.py
+++ b/mgw_api/management/commands/create_index.py
@@ -35,19 +35,31 @@ class Command(BaseCommand):
                 )
                 mani_list = self.get_manifest(manifest)
                 last_sig_files, last_num = self.get_last_index(dir_paths)
+                delete_indexed_sigs = getattr(settings, "DELETE_INDEXED_SIGS", False)
                 LOGGER.debug(f"Already in most recent index: {len(last_sig_files)}")
                 new_sig_files = self.check_updates(dir_paths)
                 LOGGER.debug(
                     f"Will be added to the above and index rebuilt: {len(new_sig_files)}"
                 )
                 if new_sig_files:
-                    sig_files = last_sig_files + new_sig_files
+                    reuse_last_index = not (
+                        delete_indexed_sigs
+                        and len(last_sig_files) == settings.INDEX_MAX_SIGNATURES
+                    )
+                    if reuse_last_index:
+                        sig_files = last_sig_files + new_sig_files
+                        start_index_number = last_num
+                    else:
+                        # Full indexes can be sealed and their signatures removed, so
+                        # only start a new batch after the latest full index.
+                        sig_files = new_sig_files
+                        start_index_number = last_num + 1
                     indexing_ever_failed = False
                     for idx_offset, new_files in enumerate(
                         batched(sig_files, n=settings.INDEX_MAX_SIGNATURES), 0
                     ):
                         self.write_signature_list(new_files, sig_list)
-                        index_number = last_num + idx_offset
+                        index_number = start_index_number + idx_offset
                         LOGGER.info(
                             f"Building index {index_number}. New index will contain {len(new_files)} signatures."
                         )
@@ -58,10 +70,20 @@ class Command(BaseCommand):
                             for k in kmers
                         ]
                         indexing_succeeded = all([val == 0 for val in retvals])
-                        target_dir = (
-                            "signatures" if indexing_succeeded else "indexing-failed"
+                        delete_after_indexing = (
+                            indexing_succeeded
+                            and delete_indexed_sigs
+                            and len(new_files) == settings.INDEX_MAX_SIGNATURES
                         )
-                        self.move_files(new_files, dir_paths, target_dir)
+                        if delete_after_indexing:
+                            self.delete_files(new_files)
+                        else:
+                            target_dir = (
+                                "signatures"
+                                if indexing_succeeded
+                                else "indexing-failed"
+                            )
+                            self.move_files(new_files, dir_paths, target_dir)
                         if indexing_succeeded:
                             self.update_manifests(
                                 new_files, mani_list, manifest, dir_paths, index_number
@@ -185,6 +207,11 @@ class Command(BaseCommand):
                 pass
             destination = os.path.join(dir_paths[target_dir], base_name)
             shutil.move(file, destination)
+
+    def delete_files(self, file_list):
+        for file in file_list:
+            if os.path.exists(file):
+                os.remove(file)
 
     def update_manifests(self, new_files, mani_list, manifest, dir_paths, last_num):
         new_files = [os.path.basename(file).split(".sig")[0] for file in new_files]

--- a/mgw_api/management/commands/create_index.py
+++ b/mgw_api/management/commands/create_index.py
@@ -34,7 +34,9 @@ class Command(BaseCommand):
                     ["updates", "index", "signatures", "indexing-failed", "manifests"],
                 )
                 mani_list = self.get_manifest(manifest)
-                last_sig_files, last_num = self.get_last_index(dir_paths)
+                last_sig_files, last_num, has_existing_index = self.get_last_index(
+                    dir_paths
+                )
                 delete_indexed_sigs = getattr(settings, "DELETE_INDEXED_SIGS", False)
                 LOGGER.debug(f"Already in most recent index: {len(last_sig_files)}")
                 new_sig_files = self.check_updates(dir_paths)
@@ -42,16 +44,16 @@ class Command(BaseCommand):
                     f"Will be added to the above and index rebuilt: {len(new_sig_files)}"
                 )
                 if new_sig_files:
-                    reuse_last_index = not (
-                        delete_indexed_sigs
-                        and len(last_sig_files) == settings.INDEX_MAX_SIGNATURES
+                    reuse_last_index = self.can_reuse_last_index(
+                        last_sig_files, has_existing_index
                     )
                     if reuse_last_index:
                         sig_files = last_sig_files + new_sig_files
                         start_index_number = last_num
                     else:
                         # Full indexes can be sealed and their signatures removed, so
-                        # only start a new batch after the latest full index.
+                        # only start a new batch after the latest index when the
+                        # manifest signatures are no longer available on disk.
                         sig_files = new_sig_files
                         start_index_number = last_num + 1
                     indexing_ever_failed = False
@@ -139,7 +141,7 @@ class Command(BaseCommand):
             # There is no manifest. We start it at 0 or the minimum value specified in the settings
             last_num = max(settings.INDEX_MIN_ITERATOR, 0)
             last_sig_files = []
-            return last_sig_files, last_num
+            return last_sig_files, last_num, False
 
         last_num = max(
             [int(f.name.split("db")[1].split(".pickle")[0]) for f in manifests]
@@ -151,7 +153,22 @@ class Command(BaseCommand):
         last_sig_files = [
             os.path.join(dir_paths["signatures"], f"{ID}.sig") for ID in last_sig_IDs
         ]
-        return last_sig_files, last_num
+        available_last_sig_files = [
+            sig_file for sig_file in last_sig_files if os.path.exists(sig_file)
+        ]
+        missing_last_sig_files = len(last_sig_files) - len(available_last_sig_files)
+        if missing_last_sig_files:
+            LOGGER.info(
+                f"Skipping {missing_last_sig_files} missing signature files from manifest db{last_num}.pickle."
+            )
+        return available_last_sig_files, last_num, True
+
+    def can_reuse_last_index(self, last_sig_files, has_existing_index):
+        if not has_existing_index:
+            return True
+        if not last_sig_files:
+            return False
+        return all(os.path.exists(sig_file) for sig_file in last_sig_files)
 
     def check_updates(self, dir_paths):
         return glob.glob(os.path.join(dir_paths["updates"], "*.sig"))

--- a/vars.env.example
+++ b/vars.env.example
@@ -24,3 +24,7 @@ LDAP_ATTR_EMAIL=mail
 # The maximum number of search results to show in the results table. Doesn't
 # limit the number of results in the downloaded result files.
 #MAX_SEARCH_RESULTS=100
+
+# Delete signatures after a successful full index batch instead of moving them
+# into metagenomes/signatures.
+DELETE_INDEXED_SIGS=False


### PR DESCRIPTION
The size of all signatures plus all indexes is too much for the space we currently have available. To help with this situation we delete signatures after an index is built. Only delete them when the index is "full", meaning that it has the maximum size we allow in a single index.
