### PR TITLE
Split 03: move processing onto Celery jobs

### DIFF
--- a/compose-dev.yml
+++ b/compose-dev.yml
@@ -32,3 +32,6 @@ services:
   mgwatch-mongodb:
     ports: !override
       - "27018:27017"
+  mgwatch-redis:
+    ports: !override
+      - "6379:6379"

--- a/compose.yml
+++ b/compose.yml
@@ -23,24 +23,58 @@ services:
     depends_on:
       mgwatch-mongodb:
         condition: service_started
-  # This container just handles running cron jobs set up by the above backend
-  # container
-  mgwatch-cron:
+      mgwatch-redis:
+        condition: service_started
+  mgwatch-celery-interactive:
     image: mgwatch:local
-    container_name: mgwatch-cron
+    container_name: mgwatch-celery-interactive
     volumes:
       - ./vars.env:/code/vars.env:ro
       - /etc/ssl/certs:/etc/ssl/certs:ro
       - ${EXTERNAL_DATA_DIR}/backend-data:/data
-      # Persist mgwatch cron jobs
-      - ${EXTERNAL_DATA_DIR}/backend-crontabs:/var/spool/cron/crontabs
       - ${SQLITE_DIR}:/data-db
       - ${LOG_DIR}:/logs
     environment:
       - TZ=$TZ
       - SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
     entrypoint: /bin/sh -c
-    command: ["/usr/sbin/cron -f"]
+    command: ["conda run --no-capture-output -n mgw celery -A mgw worker --queues interactive --concurrency 2 --hostname interactive@%h"]
+    restart: unless-stopped
+    depends_on:
+      mgwatch:
+        condition: service_started
+  mgwatch-celery-maintenance:
+    image: mgwatch:local
+    container_name: mgwatch-celery-maintenance
+    volumes:
+      - ./vars.env:/code/vars.env:ro
+      - /etc/ssl/certs:/etc/ssl/certs:ro
+      - ${EXTERNAL_DATA_DIR}/backend-data:/data
+      - ${SQLITE_DIR}:/data-db
+      - ${LOG_DIR}:/logs
+    environment:
+      - TZ=$TZ
+      - SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+    entrypoint: /bin/sh -c
+    command: ["conda run --no-capture-output -n mgw celery -A mgw worker --queues maintenance,indexing,watches --concurrency 1 --hostname maintenance@%h"]
+    restart: unless-stopped
+    depends_on:
+      mgwatch:
+        condition: service_started
+  mgwatch-celery-beat:
+    image: mgwatch:local
+    container_name: mgwatch-celery-beat
+    volumes:
+      - ./vars.env:/code/vars.env:ro
+      - /etc/ssl/certs:/etc/ssl/certs:ro
+      - ${EXTERNAL_DATA_DIR}/backend-data:/data
+      - ${SQLITE_DIR}:/data-db
+      - ${LOG_DIR}:/logs
+    environment:
+      - TZ=$TZ
+      - SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+    entrypoint: /bin/sh -c
+    command: ["conda run --no-capture-output -n mgw celery -A mgw beat --loglevel INFO"]
     restart: unless-stopped
     depends_on:
       mgwatch:
@@ -56,4 +90,8 @@ services:
       - ${MONGODB_DATA_DIR}:/data/db
       - ${MONGODB_LOG_DIR}:/data/logs
     command: --logpath /data/logs/mongodb.log
+    restart: unless-stopped
+  mgwatch-redis:
+    image: redis:7-alpine
+    container_name: mgwatch-redis
     restart: unless-stopped

--- a/environment.yml
+++ b/environment.yml
@@ -29,5 +29,8 @@ dependencies:
   - conda-forge::aiohttp
   - conda-forge::rich=14.2.0
   - conda-forge::whitenoise=6.12.0
+  - conda-forge::celery=5.5.3
+  - conda-forge::redis-py=6.4.0
   - pip:
       - django-auth-ldap==5.0.0
+      - django-redis==5.4.0

--- a/mgw/__init__.py
+++ b/mgw/__init__.py
@@ -1,0 +1,3 @@
+from .celery import app as celery_app
+
+__all__ = ("celery_app",)

--- a/mgw/celery.py
+++ b/mgw/celery.py
@@ -1,0 +1,9 @@
+import os
+
+from celery import Celery
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "mgw.settings")
+
+app = Celery("mgw")
+app.config_from_object("django.conf:settings", namespace="CELERY")
+app.autodiscover_tasks()

--- a/mgw/settings.py
+++ b/mgw/settings.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import environ
 import ldap
+from celery.schedules import crontab
 from django_auth_ldap.config import LDAPSearch
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -58,6 +59,12 @@ env = environ.Env(
     LDAP_ATTR_USERNAME=(str, None),
     LDAP_ATTR_EMAIL=(str, None),
     MAX_SEARCH_RESULTS=(int, 100),
+    REDIS_URL=(str, "redis://mgwatch-redis:6379/0"),
+    CELERY_TASK_ALWAYS_EAGER=(bool, False),
+    CELERY_TASK_EAGER_PROPAGATES=(bool, True),
+    CELERY_TASK_RESULT_TIMEOUT=(int, 60 * 60 * 6),
+    CELERY_LOCK_TIMEOUT=(int, 60 * 60 * 6),
+    CELERY_LOCK_BLOCKING_TIMEOUT=(int, 60),
 )
 
 environ.Env.read_env(BASE_DIR / "vars.env")
@@ -242,6 +249,61 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 MEDIA_ROOT = DATA_DIR / "media"
 MEDIA_URL = "/media/"
+
+REDIS_URL = env("REDIS_URL")
+
+CELERY_BROKER_URL = REDIS_URL
+CELERY_RESULT_BACKEND = REDIS_URL
+CELERY_TASK_ALWAYS_EAGER = env("CELERY_TASK_ALWAYS_EAGER")
+CELERY_TASK_EAGER_PROPAGATES = env("CELERY_TASK_EAGER_PROPAGATES")
+CELERY_TASK_TRACK_STARTED = True
+CELERY_TASK_TIME_LIMIT = env("CELERY_TASK_RESULT_TIMEOUT")
+CELERY_TASK_SOFT_TIME_LIMIT = max(1, CELERY_TASK_TIME_LIMIT - 60)
+CELERY_TASK_RESULT_EXPIRES = 60 * 60 * 24
+CELERY_WORKER_PREFETCH_MULTIPLIER = 1
+CELERY_TASK_ACKS_LATE = True
+CELERY_TASK_ACKS_ON_FAILURE_OR_TIMEOUT = True
+CELERY_TASK_REJECT_ON_WORKER_LOST = False
+CELERY_TASK_DEFAULT_QUEUE = "maintenance"
+CELERY_TASK_DEFAULT_PRIORITY = 5
+CELERY_TASK_ROUTES = {
+    "mgw_api.tasks.run_signature_pipeline": {"queue": "interactive"},
+    "mgw_api.tasks.run_search_task": {"queue": "interactive"},
+    "mgw_api.tasks.run_create_signature_task": {"queue": "interactive"},
+    "mgw_api.tasks.run_metadata_task": {"queue": "maintenance"},
+    "mgw_api.tasks.run_downloads_task": {"queue": "maintenance"},
+    "mgw_api.tasks.run_index_task": {"queue": "indexing"},
+    "mgw_api.tasks.run_watch_task": {"queue": "watches"},
+    "mgw_api.tasks.run_daily_pipeline_task": {"queue": "maintenance"},
+}
+CELERY_BEAT_SCHEDULE = {
+    "daily-maintenance-pipeline": {
+        "task": "mgw_api.tasks.run_daily_pipeline_task",
+        "schedule": crontab(minute=0, hour=1),
+        "options": {"queue": "maintenance"},
+    }
+}
+CELERY_TASK_RESULT_TIMEOUT = env("CELERY_TASK_RESULT_TIMEOUT")
+CELERY_LOCK_TIMEOUT = env("CELERY_LOCK_TIMEOUT")
+CELERY_LOCK_BLOCKING_TIMEOUT = env("CELERY_LOCK_BLOCKING_TIMEOUT")
+
+if CELERY_TASK_ALWAYS_EAGER:
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "mgwatch-local-cache",
+        }
+    }
+else:
+    CACHES = {
+        "default": {
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": REDIS_URL,
+            "OPTIONS": {
+                "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            },
+        }
+    }
 
 if DEBUG:
     MIDDLEWARE += ("debug_toolbar.middleware.DebugToolbarMiddleware",)

--- a/mgw_api/admin.py
+++ b/mgw_api/admin.py
@@ -3,6 +3,7 @@
 from django.contrib import admin
 
 from .models import Fasta
+from .models import Job
 from .models import Result
 from .models import Settings
 from .models import Signature
@@ -11,3 +12,4 @@ admin.site.register(Fasta)
 admin.site.register(Signature)
 admin.site.register(Settings)
 admin.site.register(Result)
+admin.site.register(Job)

--- a/mgw_api/apps.py
+++ b/mgw_api/apps.py
@@ -1,13 +1,4 @@
-# mgw_api/apps.py
-
-import os
-import signal
-import sys
-
 from django.apps import AppConfig
-from django.core.management import call_command
-
-from mgw.settings import LOGGER
 
 
 class MgwApiConfig(AppConfig):
@@ -15,16 +6,4 @@ class MgwApiConfig(AppConfig):
     name = "mgw_api"
 
     def ready(self):
-        # Extra code to initialize cronjobs. Copied from custom runserver.
-        self.manage_py_path = os.path.abspath("manage.py")
-        LOGGER.info("Adding cron jobs to crontab.")
-        call_command("create_crons", "add", self.manage_py_path)
-
-        # Stop cron jobs on exit
-        signal.signal(signal.SIGINT, self.stop_services)
-        signal.signal(signal.SIGTERM, self.stop_services)
-
-    def stop_services(self, signum, frame):
-        LOGGER.info("Removing cron jobs from crontab.")
-        call_command("create_crons", "remove", self.manage_py_path)
-        sys.exit(0)
+        return

--- a/mgw_api/functions.py
+++ b/mgw_api/functions.py
@@ -1,16 +1,12 @@
 # mgw_api/functions.py
 
-import io
 import re
 
 import pandas as pd
 import pymongo as pm
 from django.conf import settings
-from django.core.management import call_command
 
 from mgw.settings import LOGGER
-
-from .models import Fasta
 
 
 def search_mongodb(headers, rows):
@@ -95,34 +91,6 @@ def apply_compare(modifier, rows, column, value):
             return False
     except (ValueError, TypeError):
         return True
-
-
-def run_create_signature_and_search(user_id, name, fasta_id, do_sketching):
-    try:
-        fasta = Fasta.objects.get(id=fasta_id)
-        if do_sketching:
-            LOGGER.info(f"Calling create_signature with args: {user_id} {name}")
-            call_command("create_signature", user_id, name)
-        output = io.StringIO()
-        LOGGER.info(
-            f"Calling create_search with args: user_id={user_id} name={name} False"
-        )
-        call_command("create_search", user_id, name, "False", stdout=output)
-        output.seek(0)
-        match = re.search(r"RESULT_PK:\s*(\d+)", output.getvalue())
-        result_pk = int(match.group(1)) if match else None
-        LOGGER.info(f"Search Result pk: {result_pk}")
-        if result_pk:
-            fasta.result_pk = result_pk
-            fasta.processed = True
-            fasta.status = "Complete"
-            fasta.save()
-        else:
-            raise Exception("Search failed.")
-    except Exception as e:
-        LOGGER.error(f"Error during background processing: {e}")
-        fasta.status = f"Error: {e}"
-        fasta.save()
 
 
 def human_sort_key(text):

--- a/mgw_api/locking.py
+++ b/mgw_api/locking.py
@@ -1,0 +1,41 @@
+from contextlib import contextmanager
+from threading import Lock
+
+from django.conf import settings
+from django.core.cache import caches
+
+from .services.exceptions import LockTimeoutError
+
+_LOCAL_LOCKS = {}
+
+
+def _get_local_lock(name):
+    if name not in _LOCAL_LOCKS:
+        _LOCAL_LOCKS[name] = Lock()
+    return _LOCAL_LOCKS[name]
+
+
+@contextmanager
+def acquire_lock(name, *, timeout=None, blocking_timeout=None):
+    timeout = timeout or settings.CELERY_LOCK_TIMEOUT
+    blocking_timeout = blocking_timeout or settings.CELERY_LOCK_BLOCKING_TIMEOUT
+    cache = caches["default"]
+    if hasattr(cache, "lock"):
+        lock = cache.lock(name, timeout=timeout, blocking_timeout=blocking_timeout)
+        acquired = lock.acquire(blocking=True)
+        if not acquired:
+            raise LockTimeoutError(f"Could not acquire lock '{name}'.")
+        try:
+            yield
+        finally:
+            lock.release()
+        return
+
+    lock = _get_local_lock(name)
+    acquired = lock.acquire(timeout=blocking_timeout)
+    if not acquired:
+        raise LockTimeoutError(f"Could not acquire local lock '{name}'.")
+    try:
+        yield
+    finally:
+        lock.release()

--- a/mgw_api/management/commands/_celery.py
+++ b/mgw_api/management/commands/_celery.py
@@ -1,0 +1,16 @@
+from django.conf import settings
+from django.core.management.base import CommandError
+
+from mgw_api.tasks import submit_task_and_wait
+
+
+def wait_for_task(task, *, kwargs=None, queue=None):
+    try:
+        return submit_task_and_wait(
+            task,
+            kwargs=kwargs or {},
+            queue=queue,
+            timeout=settings.CELERY_TASK_RESULT_TIMEOUT,
+        )
+    except Exception as exc:
+        raise CommandError(str(exc)) from exc

--- a/mgw_api/management/commands/create_daily.py
+++ b/mgw_api/management/commands/create_daily.py
@@ -1,15 +1,11 @@
 from django.core.management.base import BaseCommand
 
-from mgw_api.services.maintenance import run_downloads
-from mgw_api.services.maintenance import run_index
-from mgw_api.services.maintenance import run_metadata
-from mgw_api.services.maintenance import run_watch
+from mgw_api.management.commands._celery import wait_for_task
+from mgw_api.tasks import MAINTENANCE_QUEUE
+from mgw_api.tasks import run_daily_pipeline_task
 
 
 class Command(BaseCommand):
     def handle(self, *args, **kwargs):
-        run_metadata()
-        run_downloads()
-        run_index()
-        run_watch()
+        wait_for_task(run_daily_pipeline_task, queue=MAINTENANCE_QUEUE)
         self.stdout.write(self.style.SUCCESS("Daily update completed"))

--- a/mgw_api/management/commands/create_downloads.py
+++ b/mgw_api/management/commands/create_downloads.py
@@ -1,6 +1,8 @@
 from django.core.management.base import BaseCommand
 
-from mgw_api.services.maintenance import run_downloads
+from mgw_api.management.commands._celery import wait_for_task
+from mgw_api.tasks import MAINTENANCE_QUEUE
+from mgw_api.tasks import run_downloads_task
 
 
 class Command(BaseCommand):
@@ -12,11 +14,15 @@ class Command(BaseCommand):
         parser.add_argument("--retry-failed", action="store_true")
 
     def handle(self, *args, **kwargs):
-        run_downloads(
-            max_downloads=kwargs["max_downloads"],
-            max_simultaneous=kwargs["max_simultaneous"],
-            timeout=kwargs["timeout"],
-            ids=kwargs["ids"],
-            retry_failed=kwargs["retry_failed"],
+        wait_for_task(
+            run_downloads_task,
+            kwargs={
+                "max_downloads": kwargs["max_downloads"],
+                "max_simultaneous": kwargs["max_simultaneous"],
+                "timeout": kwargs["timeout"],
+                "ids": kwargs["ids"],
+                "retry_failed": kwargs["retry_failed"],
+            },
+            queue=MAINTENANCE_QUEUE,
         )
         self.stdout.write(self.style.SUCCESS("Signature downloads completed"))

--- a/mgw_api/management/commands/create_index.py
+++ b/mgw_api/management/commands/create_index.py
@@ -1,9 +1,11 @@
 from django.core.management.base import BaseCommand
 
-from mgw_api.services.maintenance import run_index
+from mgw_api.management.commands._celery import wait_for_task
+from mgw_api.tasks import INDEX_QUEUE
+from mgw_api.tasks import run_index_task
 
 
 class Command(BaseCommand):
     def handle(self, *args, **kwargs):
-        run_index()
+        wait_for_task(run_index_task, queue=INDEX_QUEUE)
         self.stdout.write(self.style.SUCCESS("Index update completed"))

--- a/mgw_api/management/commands/create_metadata.py
+++ b/mgw_api/management/commands/create_metadata.py
@@ -1,36 +1,26 @@
 from django.core.management.base import BaseCommand
 
-from mgw_api.services.maintenance import run_metadata
+from mgw_api.management.commands._celery import wait_for_task
+from mgw_api.tasks import MAINTENANCE_QUEUE
+from mgw_api.tasks import run_metadata_task
 
 
 class Command(BaseCommand):
     def add_arguments(self, parser):
-        parser.add_argument(
-            "--no-download",
-            action="store_true",
-            help="Do not download latest SRA metadata from S3",
-        )
-        parser.add_argument(
-            "--no-process",
-            action="store_true",
-            help="Do not process the downloaded SRA data and load it into the mongodb",
-        )
-        parser.add_argument(
-            "--drop-first",
-            action="store_true",
-            help="Drop the old metadata collection before creating the new one",
-        )
-        parser.add_argument(
-            "--indexed-only",
-            action="store_true",
-            help="Only save metadata for sequences already in the search index",
-        )
+        parser.add_argument("--no-download", action="store_true")
+        parser.add_argument("--no-process", action="store_true")
+        parser.add_argument("--drop-first", action="store_true")
+        parser.add_argument("--indexed-only", action="store_true")
 
     def handle(self, *args, **kwargs):
-        run_metadata(
-            no_download=kwargs["no_download"],
-            no_process=kwargs["no_process"],
-            drop_first=kwargs["drop_first"],
-            indexed_only=kwargs["indexed_only"],
+        wait_for_task(
+            run_metadata_task,
+            kwargs={
+                "no_download": kwargs["no_download"],
+                "no_process": kwargs["no_process"],
+                "drop_first": kwargs["drop_first"],
+                "indexed_only": kwargs["indexed_only"],
+            },
+            queue=MAINTENANCE_QUEUE,
         )
         self.stdout.write(self.style.SUCCESS("Metadata update completed"))

--- a/mgw_api/management/commands/create_search.py
+++ b/mgw_api/management/commands/create_search.py
@@ -1,7 +1,12 @@
 from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
 
+from mgw_api.management.commands._celery import wait_for_task
+from mgw_api.models import Job
 from mgw_api.models import Signature
-from mgw_api.services.searches import run_search
+from mgw_api.services.jobs import create_search_job
+from mgw_api.tasks import INTERACTIVE_QUEUE
+from mgw_api.tasks import run_search_task
 
 
 class Command(BaseCommand):
@@ -11,12 +16,40 @@ class Command(BaseCommand):
         parser.add_argument("watch", type=str, nargs="?", default="False")
 
     def handle(self, *args, **kwargs):
-        user_id = kwargs["user_id"]
-        name = kwargs["name"]
-        watch = kwargs["watch"]
+        user_id, name, watch = kwargs["user_id"], kwargs["name"], kwargs["watch"]
         if watch == "False":
             signature = Signature.objects.get(user_id=user_id, name=name)
             signature.submitted = True
             signature.save(update_fields=["submitted"])
-        result = run_search(user_id=user_id, name=name, watch=watch)
+            try:
+                job = create_search_job(signature=signature, queue=INTERACTIVE_QUEUE)
+            except Exception as exc:
+                raise CommandError(str(exc)) from exc
+            result = wait_for_task(
+                run_search_task,
+                kwargs={
+                    "job_id": job.pk,
+                    "user_id": user_id,
+                    "name": name,
+                    "watch": watch,
+                },
+                queue=INTERACTIVE_QUEUE,
+            )
+        else:
+            temp_job = Job.objects.create(
+                job_type=Job.JobType.WATCH,
+                queue=INTERACTIVE_QUEUE,
+                user_id=user_id,
+                status_message="Queued",
+            )
+            result = wait_for_task(
+                run_search_task,
+                kwargs={
+                    "job_id": temp_job.pk,
+                    "user_id": user_id,
+                    "name": name,
+                    "watch": watch,
+                },
+                queue=INTERACTIVE_QUEUE,
+            )
         self.stdout.write(self.style.SUCCESS(f"RESULT_PK: {result['result_pk']}"))

--- a/mgw_api/management/commands/create_signature.py
+++ b/mgw_api/management/commands/create_signature.py
@@ -1,6 +1,8 @@
 from django.core.management.base import BaseCommand
 
-from mgw_api.services.signatures import create_signature
+from mgw_api.management.commands._celery import wait_for_task
+from mgw_api.tasks import INTERACTIVE_QUEUE
+from mgw_api.tasks import run_create_signature_task
 
 
 class Command(BaseCommand):
@@ -9,5 +11,9 @@ class Command(BaseCommand):
         parser.add_argument("name", type=str, help="Name of the fasta file")
 
     def handle(self, *args, **kwargs):
-        signature = create_signature(user_id=kwargs["user_id"], name=kwargs["name"])
-        self.stdout.write(self.style.SUCCESS(f"SIGNATURE_PK: {signature.pk}"))
+        result = wait_for_task(
+            run_create_signature_task,
+            kwargs={"user_id": kwargs["user_id"], "name": kwargs["name"]},
+            queue=INTERACTIVE_QUEUE,
+        )
+        self.stdout.write(self.style.SUCCESS(f"SIGNATURE_PK: {result['signature_id']}"))

--- a/mgw_api/management/commands/create_watch.py
+++ b/mgw_api/management/commands/create_watch.py
@@ -1,9 +1,11 @@
 from django.core.management.base import BaseCommand
 
-from mgw_api.services.maintenance import run_watch
+from mgw_api.management.commands._celery import wait_for_task
+from mgw_api.tasks import WATCH_QUEUE
+from mgw_api.tasks import run_watch_task
 
 
 class Command(BaseCommand):
     def handle(self, *args, **kwargs):
-        run_watch()
+        wait_for_task(run_watch_task, queue=WATCH_QUEUE)
         self.stdout.write(self.style.SUCCESS("Watches completed"))

--- a/mgw_api/management/commands/runserver.py
+++ b/mgw_api/management/commands/runserver.py
@@ -1,8 +1,6 @@
 # mgw_api/management/commands/runserver.py
 
 import os
-import signal
-import sys
 
 from django.conf import settings
 from django.contrib.staticfiles.management.commands.runserver import (
@@ -15,11 +13,7 @@ from mgw.settings import LOGGER
 
 class Command(StaticRunServerCommand):
     def run(self, **options):
-        self.manage_py_path = os.path.abspath("manage.py")
         if os.environ.get("RUN_MAIN") != "true":
-            # Start cron jobs
-            LOGGER.info("Starting cron jobs.")
-            call_command("create_crons", "add", self.manage_py_path)
             # Create initial metadata
             init_flag = os.path.join(
                 settings.DATA_DIR, "SRA", "metadata", "initial_setup.txt"
@@ -30,14 +24,5 @@ class Command(StaticRunServerCommand):
                 # before arguments were added to create_metadata
                 call_command("create_metadata", "--no-download")
 
-        # Stop cron jobs and mail server on exit
-        signal.signal(signal.SIGINT, self.stop_services)
-        signal.signal(signal.SIGTERM, self.stop_services)
-
         # Call Django's runserver
         super().run(**options)
-
-    def stop_services(self, signum, frame):
-        LOGGER.info("Stopping cron jobs.")
-        call_command("create_crons", "remove", self.manage_py_path)
-        sys.exit(0)

--- a/mgw_api/migrations/0033_job.py
+++ b/mgw_api/migrations/0033_job.py
@@ -1,0 +1,61 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+from django.db.models import Q
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("mgw_api", "0032_remove_result_size_result_num_results"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Job",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("job_type", models.CharField(choices=[("signature_pipeline", "Signature pipeline"), ("search", "Search"), ("create_signature", "Create signature"), ("metadata", "Metadata"), ("downloads", "Downloads"), ("index", "Index"), ("watch", "Watch"), ("daily", "Daily")], max_length=64)),
+                ("state", models.CharField(choices=[("queued", "Queued"), ("waiting", "Waiting"), ("starting", "Starting"), ("running", "Running"), ("combining_results", "Combining results"), ("saving_result", "Saving result"), ("completed", "Completed"), ("failed", "Failed")], default="queued", max_length=32)),
+                ("status_message", models.CharField(default="Queued", max_length=255)),
+                ("celery_task_id", models.CharField(blank=True, max_length=255)),
+                ("queue", models.CharField(blank=True, max_length=64)),
+                ("lock_name", models.CharField(blank=True, max_length=128)),
+                ("progress_current", models.PositiveIntegerField(default=0)),
+                ("progress_total", models.PositiveIntegerField(default=0)),
+                ("error_message", models.TextField(blank=True)),
+                ("failure_details", models.JSONField(blank=True, default=dict)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("started_at", models.DateTimeField(blank=True, null=True)),
+                ("finished_at", models.DateTimeField(blank=True, null=True)),
+                ("fasta", models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to="mgw_api.fasta")),
+                ("result", models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to="mgw_api.result")),
+                ("signature", models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to="mgw_api.signature")),
+                ("user", models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+        migrations.AddConstraint(
+            model_name="job",
+            constraint=models.UniqueConstraint(
+                condition=Q(("fasta__isnull", False), ("job_type", "signature_pipeline"), ("state__in", ("queued", "waiting", "starting", "running", "combining_results", "saving_result"))),
+                fields=("fasta", "job_type"),
+                name="uniq_active_signature_pipeline_per_fasta",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="job",
+            constraint=models.UniqueConstraint(
+                condition=Q(("job_type", "search"), ("signature__isnull", False), ("state__in", ("queued", "waiting", "starting", "running", "combining_results", "saving_result"))),
+                fields=("signature", "job_type"),
+                name="uniq_active_search_per_signature",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="job",
+            constraint=models.UniqueConstraint(
+                condition=Q(("job_type__in", ("downloads", "index", "daily")), ("state__in", ("queued", "waiting", "starting", "running", "combining_results", "saving_result"))),
+                fields=("job_type",),
+                name="uniq_active_global_maintenance_jobs",
+            ),
+        ),
+    ]

--- a/mgw_api/models.py
+++ b/mgw_api/models.py
@@ -9,6 +9,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.validators import FileExtensionValidator
 from django.db import models
+from django.db.models import Q
 
 from mgw.settings import LOGGER
 
@@ -162,3 +163,114 @@ class FilterSetting(models.Model):
 
     def __str__(self):
         return f"{self.user.username} - {self.result.name} Filters"
+
+
+class Job(models.Model):
+    class JobType(models.TextChoices):
+        SIGNATURE_PIPELINE = "signature_pipeline", "Signature pipeline"
+        SEARCH = "search", "Search"
+        CREATE_SIGNATURE = "create_signature", "Create signature"
+        METADATA = "metadata", "Metadata"
+        DOWNLOADS = "downloads", "Downloads"
+        INDEX = "index", "Index"
+        WATCH = "watch", "Watch"
+        DAILY = "daily", "Daily"
+
+    class State(models.TextChoices):
+        QUEUED = "queued", "Queued"
+        WAITING = "waiting", "Waiting"
+        STARTING = "starting", "Starting"
+        RUNNING = "running", "Running"
+        COMBINING_RESULTS = "combining_results", "Combining results"
+        SAVING_RESULT = "saving_result", "Saving result"
+        COMPLETED = "completed", "Completed"
+        FAILED = "failed", "Failed"
+
+    ACTIVE_STATES = (
+        State.QUEUED,
+        State.WAITING,
+        State.STARTING,
+        State.RUNNING,
+        State.COMBINING_RESULTS,
+        State.SAVING_RESULT,
+    )
+
+    job_type = models.CharField(max_length=64, choices=JobType.choices)
+    state = models.CharField(max_length=32, choices=State.choices, default=State.QUEUED)
+    status_message = models.CharField(max_length=255, default="Queued")
+    celery_task_id = models.CharField(max_length=255, blank=True)
+    queue = models.CharField(max_length=64, blank=True)
+    lock_name = models.CharField(max_length=128, blank=True)
+    progress_current = models.PositiveIntegerField(default=0)
+    progress_total = models.PositiveIntegerField(default=0)
+    error_message = models.TextField(blank=True)
+    failure_details = models.JSONField(default=dict, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    started_at = models.DateTimeField(null=True, blank=True)
+    finished_at = models.DateTimeField(null=True, blank=True)
+    user = models.ForeignKey(User, null=True, blank=True, on_delete=models.CASCADE)
+    fasta = models.ForeignKey(Fasta, null=True, blank=True, on_delete=models.CASCADE)
+    signature = models.ForeignKey(
+        Signature, null=True, blank=True, on_delete=models.CASCADE
+    )
+    result = models.ForeignKey(Result, null=True, blank=True, on_delete=models.CASCADE)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["fasta", "job_type"],
+                condition=Q(
+                    fasta__isnull=False,
+                    state__in=[
+                        "queued",
+                        "waiting",
+                        "starting",
+                        "running",
+                        "combining_results",
+                        "saving_result",
+                    ],
+                    job_type="signature_pipeline",
+                ),
+                name="uniq_active_signature_pipeline_per_fasta",
+            ),
+            models.UniqueConstraint(
+                fields=["signature", "job_type"],
+                condition=Q(
+                    signature__isnull=False,
+                    state__in=[
+                        "queued",
+                        "waiting",
+                        "starting",
+                        "running",
+                        "combining_results",
+                        "saving_result",
+                    ],
+                    job_type="search",
+                ),
+                name="uniq_active_search_per_signature",
+            ),
+            models.UniqueConstraint(
+                fields=["job_type"],
+                condition=Q(
+                    state__in=[
+                        "queued",
+                        "waiting",
+                        "starting",
+                        "running",
+                        "combining_results",
+                        "saving_result",
+                    ],
+                    job_type__in=["downloads", "index", "daily"],
+                ),
+                name="uniq_active_global_maintenance_jobs",
+            ),
+        ]
+
+    def __str__(self):
+        return f"{self.job_type}:{self.pk}:{self.state}"
+
+    @property
+    def progress_percent(self):
+        if not self.progress_total:
+            return 0
+        return min(100, int((self.progress_current / self.progress_total) * 100))

--- a/mgw_api/services/jobs.py
+++ b/mgw_api/services/jobs.py
@@ -1,0 +1,238 @@
+from datetime import timedelta
+
+from celery import current_app
+from celery import states as celery_states
+from django.conf import settings
+from django.db import transaction
+from django.utils import timezone
+
+from mgw.settings import LOGGER
+from mgw_api.models import Job
+
+from .exceptions import JobConflictError
+
+STALE_JOB_GRACE_SECONDS = 60
+
+
+def _active_jobs_for_fasta(fasta):
+    return Job.objects.filter(
+        fasta=fasta,
+        job_type=Job.JobType.SIGNATURE_PIPELINE,
+        state__in=Job.ACTIVE_STATES,
+    ).order_by("-created_at")
+
+
+def _active_jobs_for_signature(signature):
+    return Job.objects.filter(
+        signature=signature,
+        job_type=Job.JobType.SEARCH,
+        state__in=Job.ACTIVE_STATES,
+    ).order_by("-created_at")
+
+
+def _job_has_exceeded_liveness_window(job):
+    started_or_created_at = job.started_at or job.created_at
+    stale_after = timedelta(
+        seconds=settings.CELERY_TASK_TIME_LIMIT + STALE_JOB_GRACE_SECONDS
+    )
+    return started_or_created_at <= timezone.now() - stale_after
+
+
+def _reconcile_active_job(job):
+    if not job or job.state not in Job.ACTIVE_STATES:
+        return job
+    if not job.celery_task_id:
+        if _job_has_exceeded_liveness_window(job):
+            mark_job_failed(
+                job,
+                RuntimeError("Job became stale before a Celery task id was recorded."),
+            )
+        return job
+
+    celery_state = current_app.AsyncResult(job.celery_task_id).state
+    if celery_state in celery_states.READY_STATES:
+        mark_job_failed(
+            job,
+            RuntimeError(
+                "Celery task "
+                f"{job.celery_task_id} reached terminal state {celery_state} "
+                f"while job {job.pk} was still marked active."
+            ),
+        )
+        return job
+    if _job_has_exceeded_liveness_window(job):
+        mark_job_failed(
+            job,
+            RuntimeError(
+                "Celery task "
+                f"{job.celery_task_id} exceeded the liveness window in state "
+                f"{celery_state}."
+            ),
+        )
+    return job
+
+
+def _reconcile_active_jobs(queryset):
+    for job in queryset:
+        _reconcile_active_job(job)
+
+
+def get_active_job_for_fasta(fasta):
+    return _active_jobs_for_fasta(fasta).first()
+
+
+def get_active_job_for_signature(signature):
+    return _active_jobs_for_signature(signature).first()
+
+
+@transaction.atomic
+def create_signature_pipeline_job(*, fasta, queue):
+    _reconcile_active_jobs(_active_jobs_for_fasta(fasta))
+    existing = get_active_job_for_fasta(fasta)
+    if existing:
+        raise JobConflictError(f"An active job already exists for fasta {fasta.pk}.")
+    return Job.objects.create(
+        job_type=Job.JobType.SIGNATURE_PIPELINE,
+        queue=queue,
+        user=fasta.user,
+        fasta=fasta,
+        status_message="Queued",
+    )
+
+
+@transaction.atomic
+def create_search_job(*, signature, queue):
+    _reconcile_active_jobs(_active_jobs_for_signature(signature))
+    existing = get_active_job_for_signature(signature)
+    if existing:
+        raise JobConflictError(
+            f"An active search job already exists for signature {signature.pk}."
+        )
+    return Job.objects.create(
+        job_type=Job.JobType.SEARCH,
+        queue=queue,
+        user=signature.user,
+        signature=signature,
+        fasta=signature.fasta,
+        status_message="Queued",
+    )
+
+
+def update_job(
+    job,
+    *,
+    state=None,
+    status_message=None,
+    progress_current=None,
+    progress_total=None,
+    celery_task_id=None,
+    error_message=None,
+    failure_details=None,
+    result=None,
+    lock_name=None,
+    started=False,
+    finished=False,
+):
+    fields = []
+    if state is not None:
+        job.state = state
+        fields.append("state")
+    if status_message is not None:
+        job.status_message = status_message[:255]
+        fields.append("status_message")
+    if progress_current is not None:
+        job.progress_current = progress_current
+        fields.append("progress_current")
+    if progress_total is not None:
+        job.progress_total = progress_total
+        fields.append("progress_total")
+    if celery_task_id is not None:
+        job.celery_task_id = celery_task_id
+        fields.append("celery_task_id")
+    if error_message is not None:
+        job.error_message = error_message
+        fields.append("error_message")
+    if failure_details is not None:
+        job.failure_details = failure_details
+        fields.append("failure_details")
+    if result is not None:
+        job.result = result
+        fields.append("result")
+    if lock_name is not None:
+        job.lock_name = lock_name
+        fields.append("lock_name")
+    if started and job.started_at is None:
+        job.started_at = timezone.now()
+        fields.append("started_at")
+    if finished:
+        job.finished_at = timezone.now()
+        fields.append("finished_at")
+    if fields:
+        job.save(update_fields=fields)
+
+
+def sync_fasta_from_job(job):
+    fasta = job.fasta
+    if not fasta:
+        return
+    if job.state == Job.State.COMPLETED:
+        fasta.status = "Complete"
+        fasta.processed = True
+    elif job.state == Job.State.FAILED:
+        fasta.status = f"Error: {job.error_message or job.status_message}"
+        fasta.processed = False
+    else:
+        fasta.status = job.status_message
+        fasta.processed = False
+    if job.result_id:
+        fasta.result_pk = job.result_id
+    fasta.save(update_fields=["status", "processed", "result_pk"])
+    LOGGER.debug("Updated fasta %s from job %s", fasta.pk, job.pk)
+
+
+def mark_job_running(job, *, message, total=0, task_id=None, lock_name=None):
+    update_job(
+        job,
+        state=Job.State.RUNNING,
+        status_message=message,
+        progress_total=total,
+        celery_task_id=task_id,
+        lock_name=lock_name,
+        started=True,
+    )
+    sync_fasta_from_job(job)
+
+
+def mark_job_progress(job, *, message, current, total):
+    update_job(
+        job,
+        state=Job.State.RUNNING,
+        status_message=message,
+        progress_current=current,
+        progress_total=total,
+    )
+    sync_fasta_from_job(job)
+
+
+def mark_job_failed(job, exc):
+    update_job(
+        job,
+        state=Job.State.FAILED,
+        status_message="Failed",
+        error_message=str(exc),
+        failure_details={"error": str(exc)},
+        finished=True,
+    )
+    sync_fasta_from_job(job)
+
+
+def mark_job_completed(job, *, message, result=None):
+    update_job(
+        job,
+        state=Job.State.COMPLETED,
+        status_message=message,
+        result=result,
+        progress_current=job.progress_total,
+        finished=True,
+    )
+    sync_fasta_from_job(job)

--- a/mgw_api/services/maintenance.py
+++ b/mgw_api/services/maintenance.py
@@ -459,21 +459,34 @@ def update_manifests(new_files, mani_list, manifest, dir_paths, last_num):
 def run_watch():
     results = Result.objects.filter(is_watched=True)
     processed = 0
+    failed = 0
     for result in results:
-        signature = Signature.objects.get(user_id=result.user.id, name=result.name)
-        signature.submitted = True
-        signature.save(update_fields=["submitted"])
-        new_result = search_watch(signature.name, signature.user.id, result.pk)
-        if compare_results(result, new_result):
-            new_result.delete()
-        else:
-            result.is_watched = False
-            new_result.is_watched = True
-            result.save(update_fields=["is_watched"])
-            new_result.save(update_fields=["is_watched"])
-            send_watch_notification(result.user, result, new_result)
-        processed += 1
-    return {"processed_watches": processed}
+        try:
+            signature = Signature.objects.get(user_id=result.user.id, name=result.name)
+            signature.submitted = True
+            signature.save(update_fields=["submitted"])
+            new_result = search_watch(signature.name, signature.user.id, result.pk)
+            if compare_results(result, new_result):
+                # Watch searches are expected to create a fresh result row. If an
+                # existing watched result is returned instead, avoid deleting it.
+                if new_result.pk != result.pk and not new_result.is_watched:
+                    new_result.delete()
+            else:
+                result.is_watched = False
+                new_result.is_watched = True
+                result.save(update_fields=["is_watched"])
+                new_result.save(update_fields=["is_watched"])
+                send_watch_notification(result.user, result, new_result)
+            processed += 1
+        except Exception:
+            failed += 1
+            LOGGER.exception(
+                "Watch run failed for result_pk=%s user_id=%s name=%s",
+                result.pk,
+                result.user_id,
+                result.name,
+            )
+    return {"processed_watches": processed, "failed_watches": failed}
 
 
 def search_watch(name, user_id, watch_pk):

--- a/mgw_api/tasks.py
+++ b/mgw_api/tasks.py
@@ -1,0 +1,254 @@
+from celery import shared_task
+from django.db import transaction
+
+from mgw_api.locking import acquire_lock
+from mgw_api.models import Job
+from mgw_api.models import Signature
+from mgw_api.services.exceptions import JobConflictError
+from mgw_api.services.jobs import create_search_job
+from mgw_api.services.jobs import create_signature_pipeline_job
+from mgw_api.services.jobs import mark_job_completed
+from mgw_api.services.jobs import mark_job_failed
+from mgw_api.services.jobs import mark_job_progress
+from mgw_api.services.jobs import mark_job_running
+from mgw_api.services.jobs import sync_fasta_from_job
+from mgw_api.services.jobs import update_job
+from mgw_api.services.searches import run_search
+from mgw_api.services.signatures import create_signature
+
+INTERACTIVE_QUEUE = "interactive"
+MAINTENANCE_QUEUE = "maintenance"
+INDEX_QUEUE = "indexing"
+WATCH_QUEUE = "watches"
+NO_RETRY_TASK_OPTIONS = {
+    "bind": True,
+    "autoretry_for": (),
+    "retry_backoff": False,
+    "max_retries": 0,
+}
+
+
+def _queue_for_job_type(job_type):
+    return {
+        Job.JobType.SIGNATURE_PIPELINE: INTERACTIVE_QUEUE,
+        Job.JobType.SEARCH: INTERACTIVE_QUEUE,
+        Job.JobType.CREATE_SIGNATURE: INTERACTIVE_QUEUE,
+        Job.JobType.METADATA: MAINTENANCE_QUEUE,
+        Job.JobType.DOWNLOADS: MAINTENANCE_QUEUE,
+        Job.JobType.INDEX: INDEX_QUEUE,
+        Job.JobType.WATCH: WATCH_QUEUE,
+        Job.JobType.DAILY: MAINTENANCE_QUEUE,
+    }[job_type]
+
+
+def submit_signature_pipeline_job(*, fasta):
+    try:
+        job = create_signature_pipeline_job(fasta=fasta, queue=INTERACTIVE_QUEUE)
+    except JobConflictError:
+        return (
+            Job.objects.filter(
+                fasta=fasta,
+                job_type=Job.JobType.SIGNATURE_PIPELINE,
+                state__in=Job.ACTIVE_STATES,
+            )
+            .order_by("-created_at")
+            .first()
+        )
+
+    def enqueue():
+        async_result = run_signature_pipeline.apply_async(
+            kwargs={"job_id": job.pk, "user_id": fasta.user_id, "name": fasta.name},
+            queue=INTERACTIVE_QUEUE,
+        )
+        update_job(job, celery_task_id=async_result.id)
+        sync_fasta_from_job(job)
+
+    transaction.on_commit(enqueue)
+    return job
+
+
+def submit_search_job(*, signature):
+    try:
+        job = create_search_job(signature=signature, queue=INTERACTIVE_QUEUE)
+    except JobConflictError:
+        return (
+            Job.objects.filter(
+                signature=signature,
+                job_type=Job.JobType.SEARCH,
+                state__in=Job.ACTIVE_STATES,
+            )
+            .order_by("-created_at")
+            .first()
+        )
+
+    def enqueue():
+        async_result = run_search_task.apply_async(
+            kwargs={
+                "job_id": job.pk,
+                "user_id": signature.user_id,
+                "name": signature.name,
+                "watch": "False",
+            },
+            queue=INTERACTIVE_QUEUE,
+        )
+        update_job(job, celery_task_id=async_result.id)
+        sync_fasta_from_job(job)
+
+    transaction.on_commit(enqueue)
+    return job
+
+
+def submit_task_and_wait(task, *, kwargs, queue=None, timeout=None):
+    async_result = task.apply_async(kwargs=kwargs, queue=queue)
+    return async_result.get(timeout=timeout)
+
+
+@shared_task(**NO_RETRY_TASK_OPTIONS)
+def run_signature_pipeline(self, *, job_id, user_id, name):
+    job = Job.objects.get(pk=job_id)
+    mark_job_running(
+        job,
+        message="Creating signature",
+        task_id=self.request.id,
+    )
+    try:
+        create_signature(user_id=user_id, name=name)
+
+        def progress_callback(current, total):
+            mark_job_progress(
+                job,
+                message=f"Searching indexes {current}/{total}",
+                current=current,
+                total=total,
+            )
+
+        def state_callback(state):
+            if state == Job.State.COMBINING_RESULTS:
+                update_job(
+                    job,
+                    state=Job.State.COMBINING_RESULTS,
+                    status_message="Combining results",
+                )
+            elif state == Job.State.SAVING_RESULT:
+                update_job(
+                    job,
+                    state=Job.State.SAVING_RESULT,
+                    status_message="Saving result",
+                )
+
+        result = run_search(
+            user_id=user_id,
+            name=name,
+            watch="False",
+            progress_callback=progress_callback,
+            state_callback=state_callback,
+        )
+        signature = Signature.objects.get(user_id=user_id, name=name)
+        result_obj = signature.result_set.latest("time")
+        mark_job_completed(job, message="Complete", result=result_obj)
+        return result
+    except Exception as exc:
+        mark_job_failed(job, exc)
+        raise
+
+
+@shared_task(**NO_RETRY_TASK_OPTIONS)
+def run_search_task(self, *, job_id, user_id, name, watch="False", parent_job_id=None):
+    job = Job.objects.get(pk=job_id)
+    mark_job_running(
+        job,
+        message="Preparing search",
+        task_id=self.request.id,
+    )
+
+    def progress_callback(current, total):
+        mark_job_progress(
+            job,
+            message=f"Searching indexes {current}/{total}",
+            current=current,
+            total=total,
+        )
+        if parent_job_id:
+            parent_job = Job.objects.get(pk=parent_job_id)
+            mark_job_progress(
+                parent_job,
+                message=f"Searching indexes {current}/{total}",
+                current=current,
+                total=total,
+            )
+
+    def state_callback(state):
+        if state == Job.State.COMBINING_RESULTS:
+            update_job(
+                job,
+                state=Job.State.COMBINING_RESULTS,
+                status_message="Combining results",
+            )
+        elif state == Job.State.SAVING_RESULT:
+            update_job(
+                job,
+                state=Job.State.SAVING_RESULT,
+                status_message="Saving result",
+            )
+
+    try:
+        result = run_search(
+            user_id=user_id,
+            name=name,
+            watch=watch,
+            progress_callback=progress_callback,
+            state_callback=state_callback,
+        )
+        signature = Signature.objects.get(user_id=user_id, name=name)
+        result_obj = signature.result_set.latest("time")
+        mark_job_completed(job, message="Complete", result=result_obj)
+        return result
+    except Exception as exc:
+        mark_job_failed(job, exc)
+        raise
+
+
+@shared_task(**NO_RETRY_TASK_OPTIONS)
+def run_create_signature_task(self, *, user_id, name):
+    return {"signature_id": create_signature(user_id=user_id, name=name).pk}
+
+
+@shared_task(**NO_RETRY_TASK_OPTIONS)
+def run_metadata_task(self, **kwargs):
+    from mgw_api.services.maintenance import run_metadata
+
+    with acquire_lock("maintenance-pipeline-lock"):
+        return run_metadata(**kwargs)
+
+
+@shared_task(**NO_RETRY_TASK_OPTIONS)
+def run_downloads_task(self, **kwargs):
+    from mgw_api.services.maintenance import run_downloads
+
+    with acquire_lock("downloads-lock"):
+        with acquire_lock("download-index-exclusive-lock"):
+            return run_downloads(**kwargs)
+
+
+@shared_task(**NO_RETRY_TASK_OPTIONS)
+def run_index_task(self, **kwargs):
+    from mgw_api.services.maintenance import run_index
+
+    with acquire_lock("index-lock"):
+        with acquire_lock("download-index-exclusive-lock"):
+            return run_index(**kwargs)
+
+
+@shared_task(**NO_RETRY_TASK_OPTIONS)
+def run_watch_task(self, **kwargs):
+    from mgw_api.services.maintenance import run_watch
+
+    return run_watch(**kwargs)
+
+
+@shared_task(**NO_RETRY_TASK_OPTIONS)
+def run_daily_pipeline_task(self):
+    run_metadata_task.apply(kwargs={}).get()
+    run_downloads_task.apply(kwargs={}).get()
+    run_index_task.apply(kwargs={}).get()
+    return run_watch_task.apply(kwargs={}).get()

--- a/mgw_api/templates/mgw_api/list_result.html
+++ b/mgw_api/templates/mgw_api/list_result.html
@@ -81,6 +81,8 @@
                 Searching for matches, please wait. Do not close or reload the page. This process might take a few minutes.
             </li>
         </ul>
+        <p id="progress-label">Queued</p>
+        <progress id="search-progress" max="100" value="0">0%</progress>
     </div>
     <script>
     function handleError(message) {
@@ -108,11 +110,20 @@
 
     function pollStatus(fastaId) {
         const url = `{% url 'mgw_api:check_status' 0 %}`.replace('0', fastaId);
+        const progressEl = document.getElementById('search-progress');
+        const progressLabel = document.getElementById('progress-label');
 
         function checkStatus() {
             fetch(url)
                 .then(response => response.json())
                 .then(data => {
+                    if (progressEl && typeof data.percent !== 'undefined') {
+                        progressEl.value = data.percent;
+                    }
+                    if (progressLabel) {
+                        const countSuffix = data.total ? ` (${data.current}/${data.total})` : '';
+                        progressLabel.textContent = `${data.message || data.status}${countSuffix}`;
+                    }
                     if (data.status === 'Complete') {
                         window.location.href = `{% url 'mgw_api:result_table' 0 %}`.replace('0', data.result_pk);
                     } else if (data.status.startsWith('Error')) {

--- a/mgw_api/templates/mgw_api/list_signature.html
+++ b/mgw_api/templates/mgw_api/list_signature.html
@@ -50,9 +50,12 @@
         {% endif %}
     </div>
     <script>
-    document.getElementById('upload-form').addEventListener('submit', function(event) {
-        const submissionMessageDiv = document.querySelector('.submission-message');
-        submissionMessageDiv.innerHTML = '';
-    });
+    const uploadForm = document.getElementById('upload-form');
+    if (uploadForm) {
+        uploadForm.addEventListener('submit', function() {
+            const submissionMessageDiv = document.querySelector('.submission-message');
+            submissionMessageDiv.innerHTML = '';
+        });
+    }
     </script>
 {% endblock content %}

--- a/mgw_api/templates/mgw_api/upload_fasta.html
+++ b/mgw_api/templates/mgw_api/upload_fasta.html
@@ -23,6 +23,8 @@
                 Searching for matches, please wait. Do not close or reload the page. This process might take a few minutes.
             </li>
         </ul>
+        <p id="progress-label">Queued</p>
+        <progress id="search-progress" max="100" value="0">0%</progress>
     </div>
     <script>
     document.addEventListener('DOMContentLoaded', function () {
@@ -64,11 +66,20 @@
 
     function pollStatus(fastaId) {
         const url = `{% url 'mgw_api:check_status' 0 %}`.replace('0', fastaId);
+        const progressEl = document.getElementById('search-progress');
+        const progressLabel = document.getElementById('progress-label');
 
         function checkStatus() {
             fetch(url)
                 .then(response => response.json())
                 .then(data => {
+                    if (progressEl && typeof data.percent !== 'undefined') {
+                        progressEl.value = data.percent;
+                    }
+                    if (progressLabel) {
+                        const countSuffix = data.total ? ` (${data.current}/${data.total})` : '';
+                        progressLabel.textContent = `${data.message || data.status}${countSuffix}`;
+                    }
                     if (data.status === 'Complete') {
                         window.location.href = `{% url 'mgw_api:result_table' 0 %}`.replace('0', data.result_pk);
                     } else if (data.status.startsWith('Error')) {

--- a/mgw_api/tests/test_jobs.py
+++ b/mgw_api/tests/test_jobs.py
@@ -1,0 +1,127 @@
+import tempfile
+from datetime import timedelta
+from unittest.mock import Mock
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.test import override_settings
+from django.urls import reverse
+from django.utils import timezone
+
+from mgw_api.models import Fasta
+from mgw_api.models import Job
+from mgw_api.services.exceptions import JobConflictError
+from mgw_api.services.jobs import create_signature_pipeline_job
+
+TEST_MEDIA_ROOT = tempfile.mkdtemp()
+
+
+@override_settings(MEDIA_ROOT=TEST_MEDIA_ROOT, CELERY_TASK_ALWAYS_EAGER=True)
+class JobStatusViewTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="owner", password="testpass123")
+        self.client.login(username="owner", password="testpass123")
+        self.fasta = Fasta.objects.create(
+            user=self.user,
+            name="example",
+            size=1,
+            processed=False,
+            status="Searching indexes 1/3",
+            result_pk=None,
+            file="user_1/example.fa",
+        )
+
+    def test_check_status_includes_progress_fields(self):
+        Job.objects.create(
+            job_type=Job.JobType.SIGNATURE_PIPELINE,
+            state=Job.State.RUNNING,
+            status_message="Searching indexes 1/3",
+            progress_current=1,
+            progress_total=3,
+            user=self.user,
+            fasta=self.fasta,
+            queue="interactive",
+        )
+
+        response = self.client.get(
+            reverse("mgw_api:check_status", kwargs={"fasta_id": self.fasta.pk})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["state"], Job.State.RUNNING)
+        self.assertEqual(payload["current"], 1)
+        self.assertEqual(payload["total"], 3)
+        self.assertEqual(payload["percent"], 33)
+
+
+@override_settings(MEDIA_ROOT=TEST_MEDIA_ROOT, CELERY_TASK_TIME_LIMIT=10)
+class JobReconciliationTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="owner", password="testpass123")
+        self.fasta = Fasta.objects.create(
+            user=self.user,
+            name="example",
+            size=1,
+            processed=False,
+            status="Queued",
+            result_pk=None,
+            file="user_1/example.fa",
+        )
+
+    def test_stale_running_job_is_failed_before_creating_replacement(self):
+        active_job = Job.objects.create(
+            job_type=Job.JobType.SIGNATURE_PIPELINE,
+            state=Job.State.RUNNING,
+            status_message="Searching indexes 1/3",
+            user=self.user,
+            fasta=self.fasta,
+            queue="interactive",
+            celery_task_id="task-123",
+        )
+        stale_at = timezone.now() - timedelta(seconds=120)
+        Job.objects.filter(pk=active_job.pk).update(
+            created_at=stale_at,
+            started_at=stale_at,
+        )
+
+        with patch("mgw_api.services.jobs.current_app.AsyncResult") as async_result:
+            async_result.return_value = Mock(state="STARTED")
+            replacement = create_signature_pipeline_job(
+                fasta=self.fasta,
+                queue="interactive",
+            )
+
+        active_job.refresh_from_db()
+        self.assertEqual(active_job.state, Job.State.FAILED)
+        self.assertIn("exceeded the liveness window", active_job.error_message)
+        self.assertNotEqual(active_job.pk, replacement.pk)
+        self.assertEqual(replacement.state, Job.State.QUEUED)
+
+    def test_recent_running_job_still_conflicts(self):
+        active_job = Job.objects.create(
+            job_type=Job.JobType.SIGNATURE_PIPELINE,
+            state=Job.State.RUNNING,
+            status_message="Searching indexes 1/3",
+            user=self.user,
+            fasta=self.fasta,
+            queue="interactive",
+            celery_task_id="task-123",
+        )
+        recent_at = timezone.now() - timedelta(seconds=5)
+        Job.objects.filter(pk=active_job.pk).update(
+            created_at=recent_at,
+            started_at=recent_at,
+        )
+
+        with patch("mgw_api.services.jobs.current_app.AsyncResult") as async_result:
+            async_result.return_value = Mock(state="STARTED")
+            with self.assertRaises(JobConflictError):
+                create_signature_pipeline_job(
+                    fasta=self.fasta,
+                    queue="interactive",
+                )
+
+        active_job.refresh_from_db()
+        self.assertEqual(active_job.state, Job.State.RUNNING)

--- a/mgw_api/views.py
+++ b/mgw_api/views.py
@@ -3,9 +3,6 @@
 import json
 import os
 import re
-import subprocess
-import sys
-import threading
 
 import numpy as np
 from django.conf import settings
@@ -14,6 +11,7 @@ from django.contrib.auth import authenticate
 from django.contrib.auth import login
 from django.contrib.auth import logout
 from django.contrib.auth.decorators import login_required
+from django.db import transaction
 from django.http import FileResponse
 from django.http import Http404
 from django.http import HttpResponse
@@ -34,12 +32,14 @@ from .functions import apply_regex
 from .functions import get_numeric_columns_pandas
 from .functions import get_results_with_metadata
 from .functions import is_float
-from .functions import run_create_signature_and_search
 from .models import Fasta
 from .models import FilterSetting
+from .models import Job
 from .models import Result
 from .models import Settings
 from .models import Signature
+from .tasks import submit_search_job
+from .tasks import submit_signature_pipeline_job
 
 ################################################################
 ## account management
@@ -105,23 +105,15 @@ def upload_fasta(request):
                             }
                         )
                     else:
-                        uploaded_file_instance = fasta_form.save(commit=False)
-                        uploaded_file_instance.user = request.user
-                        uploaded_file_instance.name = name
-                        uploaded_file_instance.size = uploaded_file.size
-                        uploaded_file_instance.processed = False
-                        uploaded_file_instance.status = "Processing"
-                        uploaded_file_instance.save()
-                        thread = threading.Thread(
-                            target=run_create_signature_and_search,
-                            args=(
-                                request.user.id,
-                                name,
-                                uploaded_file_instance.id,
-                                True,
-                            ),
-                        )
-                        thread.start()
+                        with transaction.atomic():
+                            uploaded_file_instance = fasta_form.save(commit=False)
+                            uploaded_file_instance.user = request.user
+                            uploaded_file_instance.name = name
+                            uploaded_file_instance.size = uploaded_file.size
+                            uploaded_file_instance.processed = False
+                            uploaded_file_instance.status = "Queued"
+                            uploaded_file_instance.save()
+                            submit_signature_pipeline_job(fasta=uploaded_file_instance)
                         return JsonResponse(
                             {
                                 "success": True,
@@ -151,9 +143,30 @@ def upload_fasta(request):
 @login_required
 def check_processing_status(request, fasta_id):
     fasta = get_object_or_404(Fasta, id=fasta_id, user=request.user)
-    return JsonResponse(
-        {"status": fasta.status, "fasta_id": fasta_id, "result_pk": fasta.result_pk}
+    job = (
+        Job.objects.filter(fasta=fasta, user=request.user)
+        .order_by("-created_at")
+        .first()
     )
+    if job:
+        payload = {
+            "status": fasta.status,
+            "state": job.state,
+            "message": job.status_message,
+            "current": job.progress_current,
+            "total": job.progress_total,
+            "percent": job.progress_percent,
+            "fasta_id": fasta_id,
+            "result_pk": fasta.result_pk,
+            "job_id": job.pk,
+        }
+    else:
+        payload = {
+            "status": fasta.status,
+            "fasta_id": fasta_id,
+            "result_pk": fasta.result_pk,
+        }
+    return JsonResponse(payload)
 
 
 @login_required
@@ -186,22 +199,11 @@ def process_signature(request, pk):
         try:
             signature = get_object_or_404(Signature, pk=pk, user=request.user)
             current_settings = Settings.objects.get(user=request.user)
-            signature.settings_used = current_settings.to_dict()
-            signature.submitted = True
-            signature.save()
-            manage_py_path = os.path.join(
-                os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "manage.py"
-            )
-            subprocess.Popen(
-                [
-                    sys.executable,
-                    manage_py_path,
-                    "create_search",
-                    str(request.user.id),
-                    signature.name,
-                ]
-            )
-            subprocess.Popen([sys.executable, manage_py_path, "create_search"])
+            with transaction.atomic():
+                signature.settings_used = current_settings.to_dict()
+                signature.submitted = True
+                signature.save(update_fields=["settings_used", "submitted"])
+                submit_search_job(signature=signature)
             messages.success(
                 request,
                 "Signature submission successful. Processing will happen in the background.",
@@ -270,17 +272,14 @@ def list_result(request):
                 signature = get_object_or_404(
                     Signature, id=signature_id, user=request.user
                 )
-                signature.submitted = True
-                signature.save()
-                fasta = signature.fasta
-                fasta.processed = False
-                fasta.status = "Processing"
-                fasta.save()
-                thread = threading.Thread(
-                    target=run_create_signature_and_search,
-                    args=(request.user.id, fasta.name, fasta.id, False),
-                )
-                thread.start()
+                with transaction.atomic():
+                    signature.submitted = True
+                    signature.save(update_fields=["submitted"])
+                    fasta = signature.fasta
+                    fasta.processed = False
+                    fasta.status = "Queued"
+                    fasta.save(update_fields=["processed", "status"])
+                    submit_search_job(signature=signature)
                 return JsonResponse(
                     {
                         "success": True,

--- a/vars.env.example
+++ b/vars.env.example
@@ -7,6 +7,7 @@ TIME_ZONE="Europe/Berlin"
 # This is a path inside the backend docker container
 DATA_DIR="/data"
 MONGO_URI="mongodb://root:example1@mgwatch-mongodb:27017/"
+REDIS_URL="redis://mgwatch-redis:6379/0"
 # Leave this unset to skip setting all email config
 # EMAIL_HOST=localhost
 EMAIL_PORT=1025


### PR DESCRIPTION
## Summary

This is PR 3 in the split Celery/workflow stack.

- Adds Celery configuration, Redis-backed task execution, queue routing, and beat scheduling.
- Introduces the `Job` model and job service helpers for progress/state tracking.
- Moves interactive and maintenance processing paths onto Celery tasks.
- Adds tests for job behavior and stale job reconciliation.

## Stack

Base: `split/02-service-extraction`
Head: `split/03-celery-job-processing`

## Validation

- Pre-commit hooks passed when committed.
- `python -m py_compile` passed for touched task/view/service/test modules during the split.
- The GitHub Actions workflow now runs Django tests for PRs.