### PR TITLE
Split 04: show active search status with HTMX

### DIFF
--- a/mgw_api/templates/mgw_api/_job_status.html
+++ b/mgw_api/templates/mgw_api/_job_status.html
@@ -1,0 +1,10 @@
+<div class="result-job-status"
+     hx-get="{% url 'mgw_api:job_status' fasta.pk %}"
+     hx-trigger="every 5s"
+     hx-swap="outerHTML">
+    <div class="job-message">
+        {{ job.status_message }}
+        {% if job.progress_total %}({{ job.progress_current }}/{{ job.progress_total }}){% endif %}
+    </div>
+    <progress max="100" value="{{ job.progress_percent }}">{{ job.progress_percent }}%</progress>
+</div>

--- a/mgw_api/templates/mgw_api/base.html
+++ b/mgw_api/templates/mgw_api/base.html
@@ -11,6 +11,7 @@
         <link rel="stylesheet" href="{% static 'mgw_api/pico.blue.min.css' %}">
         <link rel="stylesheet" href="{% static 'mgw_api/custom.css' %}">
         <link rel="icon" href="{% static 'mgw_api/satellite-dish-solid.svg' %}">
+        <script src="https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js" defer></script>
     </head>
     <body>
         <header>

--- a/mgw_api/templates/mgw_api/list_result.html
+++ b/mgw_api/templates/mgw_api/list_result.html
@@ -11,8 +11,8 @@
                     <h3>Sequence name: {{ signature.name }}</h3>
                 </div>
                 <div class="signature-actions">
-                    {% if not signature.result_set.exists %}
-                        <a href="{% url 'mgw_api:delete_signature' signature.pk %}?next={% url 'mgw_api:list_result' %}"
+                    {% if not signature.sorted_results and signature.signature %}
+                        <a href="{% url 'mgw_api:delete_signature' signature.signature.pk %}?next={% url 'mgw_api:list_result' %}"
                            class="delete-link">delete</a>
                     {% endif %}
                     {% if False %}
@@ -20,13 +20,15 @@
                               method="post"
                               action="{% url 'mgw_api:list_result' %}">
                             {% csrf_token %}
-                            <input type="hidden" name="signature_id" value="{{ signature.pk }}">
+                            <input type="hidden"
+                                   name="signature_id"
+                                   value="{{ signature.signature.pk }}">
                             <button type="submit">Update search</button>
                         </form>
                     {% endif %}
                 </div>
             </div>
-            {% if signature.result_set.exists %}
+            {% if signature.sorted_results %}
                 Previous searches:
                 <table class="result-list">
                     <thead>
@@ -36,12 +38,13 @@
                             <th>Databases</th>
                             <th>Containment</th>
                             <th># results</th>
+                            <th>Current search</th>
                             <th>Is watched?</th>
                             <th>Delete</th>
                         </tr>
                     </thead>
                     <tbody>
-                        {% for result in signature.sorted_results.all %}
+                        {% for result in signature.sorted_results %}
                             <tr>
                                 <td>
                                     <a href="{% url 'mgw_api:result_table' result.pk %}">{{ result.date }} {{ result.time|date:"H:i:s" }}</a>
@@ -50,6 +53,15 @@
                                 <td>{{ result.database }}</td>
                                 <td>{{ result.containment }}</td>
                                 <td>{{ result.num_results }}</td>
+                                {% if forloop.first %}
+                                    <td {% if signature.sorted_results|length > 1 %}rowspan="{{ signature.sorted_results|length }}"{% endif %}>
+                                        {% if signature.active_job %}
+                                            {% include "mgw_api/_job_status.html" with fasta=signature.fasta job=signature.active_job only %}
+                                        {% else %}
+                                            <span>-</span>
+                                        {% endif %}
+                                    </td>
+                                {% endif %}
                                 <td>
                                     <form id="watch-form-{{ result.pk }}"
                                           method="post"
@@ -66,6 +78,19 @@
                                 </td>
                             </tr>
                         {% endfor %}
+                    </tbody>
+                </table>
+            {% elif signature.active_job %}
+                <table class="result-list">
+                    <thead>
+                        <tr>
+                            <th>Current search</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>{% include "mgw_api/_job_status.html" with fasta=signature.fasta job=signature.active_job only %}</td>
+                        </tr>
                     </tbody>
                 </table>
             {% endif %}

--- a/mgw_api/tests/test_jobs.py
+++ b/mgw_api/tests/test_jobs.py
@@ -11,6 +11,8 @@ from django.utils import timezone
 
 from mgw_api.models import Fasta
 from mgw_api.models import Job
+from mgw_api.models import Result
+from mgw_api.models import Signature
 from mgw_api.services.exceptions import JobConflictError
 from mgw_api.services.jobs import create_signature_pipeline_job
 
@@ -54,6 +56,107 @@ class JobStatusViewTests(TestCase):
         self.assertEqual(payload["current"], 1)
         self.assertEqual(payload["total"], 3)
         self.assertEqual(payload["percent"], 33)
+
+    def test_job_status_fragment_renders_htmx_polling_markup(self):
+        Job.objects.create(
+            job_type=Job.JobType.SIGNATURE_PIPELINE,
+            state=Job.State.RUNNING,
+            status_message="Searching indexes 1/3",
+            progress_current=1,
+            progress_total=3,
+            user=self.user,
+            fasta=self.fasta,
+            queue="interactive",
+        )
+
+        response = self.client.get(
+            reverse("mgw_api:job_status", kwargs={"fasta_id": self.fasta.pk})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'hx-trigger="every 5s"')
+        self.assertContains(
+            response,
+            reverse("mgw_api:job_status", kwargs={"fasta_id": self.fasta.pk}),
+        )
+        self.assertContains(response, "Searching indexes 1/3")
+        self.assertContains(response, 'value="33"', html=False)
+
+    def test_job_status_fragment_refreshes_when_job_is_terminal(self):
+        Job.objects.create(
+            job_type=Job.JobType.SIGNATURE_PIPELINE,
+            state=Job.State.COMPLETED,
+            status_message="Complete",
+            progress_current=3,
+            progress_total=3,
+            user=self.user,
+            fasta=self.fasta,
+            queue="interactive",
+        )
+
+        response = self.client.get(
+            reverse("mgw_api:job_status", kwargs={"fasta_id": self.fasta.pk})
+        )
+
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.headers["HX-Refresh"], "true")
+
+    def test_results_page_shows_active_search_job_progress(self):
+        signature = Signature.objects.create(
+            user=self.user,
+            name="example",
+            fasta=self.fasta,
+            file="user_1/example.sig",
+        )
+        Result.objects.create(
+            user=self.user,
+            name="example",
+            signature=signature,
+            file="user_1/example.csv",
+            num_results=7,
+            kmer=[21],
+            database=["SRA"],
+            containment=0.1,
+        )
+        Job.objects.create(
+            job_type=Job.JobType.SEARCH,
+            state=Job.State.RUNNING,
+            status_message="Searching indexes 1/3",
+            progress_current=1,
+            progress_total=3,
+            user=self.user,
+            signature=signature,
+            fasta=self.fasta,
+            queue="interactive",
+        )
+
+        response = self.client.get(reverse("mgw_api:list_result"))
+
+        self.assertContains(response, "Current search")
+        self.assertContains(response, "Searching indexes 1/3")
+        self.assertContains(response, "(1/3)")
+        self.assertContains(response, 'hx-trigger="every 5s"')
+        self.assertContains(response, 'value="33"', html=False)
+
+    def test_results_page_shows_active_signature_pipeline_without_completed_results(
+        self,
+    ):
+        Job.objects.create(
+            job_type=Job.JobType.SIGNATURE_PIPELINE,
+            state=Job.State.RUNNING,
+            status_message="Creating signature",
+            progress_current=0,
+            progress_total=0,
+            user=self.user,
+            fasta=self.fasta,
+            queue="interactive",
+        )
+
+        response = self.client.get(reverse("mgw_api:list_result"))
+
+        self.assertContains(response, "Sequence name: example")
+        self.assertContains(response, "Current search")
+        self.assertContains(response, "Creating signature")
 
 
 @override_settings(MEDIA_ROOT=TEST_MEDIA_ROOT, CELERY_TASK_TIME_LIMIT=10)

--- a/mgw_api/urls.py
+++ b/mgw_api/urls.py
@@ -30,6 +30,7 @@ urlpatterns = [
         views.check_processing_status,
         name="check_status",
     ),
+    path("job_status/<int:fasta_id>/", views.job_status, name="job_status"),
     path(
         "download/result-file/<int:pk>/",
         views.download_result_file,

--- a/mgw_api/views.py
+++ b/mgw_api/views.py
@@ -3,6 +3,7 @@
 import json
 import os
 import re
+from types import SimpleNamespace
 
 import numpy as np
 from django.conf import settings
@@ -170,6 +171,25 @@ def check_processing_status(request, fasta_id):
 
 
 @login_required
+def job_status(request, fasta_id):
+    fasta = get_object_or_404(Fasta, id=fasta_id, user=request.user)
+    job = (
+        Job.objects.filter(fasta=fasta, user=request.user)
+        .order_by("-created_at")
+        .first()
+    )
+    if job and job.state in Job.ACTIVE_STATES:
+        return render(
+            request,
+            "mgw_api/_job_status.html",
+            {"fasta": fasta, "job": job},
+        )
+    response = HttpResponse(status=204)
+    response["HX-Refresh"] = "true"
+    return response
+
+
+@login_required
 def list_signature(request):
     signature_files = Signature.objects.filter(user=request.user)
     return render(
@@ -299,12 +319,68 @@ def list_result(request):
         .prefetch_related("result_set")
         .order_by("-date", "-time")
     )
+    active_search_jobs = {}
+    for job in Job.objects.filter(
+        user=request.user,
+        job_type=Job.JobType.SEARCH,
+        state__in=Job.ACTIVE_STATES,
+        signature__in=signatures,
+    ).order_by("signature_id", "-created_at"):
+        active_search_jobs.setdefault(job.signature_id, job)
+    entries_by_name = {}
     for signature in signatures:
-        signature.sorted_results = signature.result_set.all().order_by("-date", "-time")
+        entry = entries_by_name.setdefault(
+            signature.name,
+            SimpleNamespace(
+                name=signature.name,
+                signature=signature,
+                fasta=signature.fasta,
+                sorted_results=[],
+                active_job=None,
+            ),
+        )
+        entry.signature = signature
+        entry.fasta = signature.fasta
+        entry.sorted_results = list(
+            signature.result_set.all().order_by("-date", "-time")
+        )
+        entry.active_job = active_search_jobs.get(signature.pk)
+    for job in (
+        Job.objects.filter(
+            user=request.user,
+            job_type=Job.JobType.SIGNATURE_PIPELINE,
+            state__in=Job.ACTIVE_STATES,
+        )
+        .select_related("fasta")
+        .order_by("-created_at")
+    ):
+        if not job.fasta:
+            continue
+        entry = entries_by_name.setdefault(
+            job.fasta.name,
+            SimpleNamespace(
+                name=job.fasta.name,
+                signature=None,
+                fasta=job.fasta,
+                sorted_results=[],
+                active_job=None,
+            ),
+        )
+        if entry.active_job is None:
+            entry.active_job = job
+        if entry.fasta is None:
+            entry.fasta = job.fasta
+    sequence_entries = list(entries_by_name.values())
+    sequence_entries.sort(
+        key=lambda entry: (
+            entry.signature.date if entry.signature else entry.fasta.upload_date
+        ),
+        reverse=True,
+    )
     return render(
         request,
         "mgw_api/list_result.html",
-        {"signatures": signatures, "settings_form": settings_form},
+        {"signatures": sequence_entries, "settings_form": settings_form},
     )
 
 


### PR DESCRIPTION
## Summary

This is PR 4 in the split Celery/workflow stack.

- Groups result entries so active jobs can be shown next to completed search results.
- Adds HTMX globally and a reusable `_job_status.html` partial for polling active job status.
- Adds a `job_status/{fasta_id}/` partial endpoint that refreshes the page when the active job reaches a terminal state.
- Adds tests for the HTMX partial, terminal refresh response, and result-page status rendering.

## Stack

Base: `split/03-celery-job-processing`
Head: `split/04-search-status-ui`

## Validation

- Pre-commit hooks passed when amended.
- `python -m py_compile mgw_api/views.py mgw_api/urls.py mgw_api/tests/test_jobs.py` passed.