### PR TITLE
Split 05: use updates directory as download state

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -14,7 +14,6 @@ services:
     environment:
       - TZ=$TZ
       - SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
-      - MAX_DOWNLOADS=$MAX_DOWNLOADS
     entrypoint: /bin/sh -c
     command: ["conda run --no-capture-output -n mgw gunicorn --workers 2 --threads 2 --bind 0.0.0.0:8100 mgw.wsgi:application"]
     restart: unless-stopped

--- a/mgw_api/services/maintenance.py
+++ b/mgw_api/services/maintenance.py
@@ -157,7 +157,6 @@ def run_downloads(
     )
     metagenomes_dir = settings.DATA_DIR / database / "metagenomes"
     manifest = metagenomes_dir / "manifest.pickle"
-    man_succ = metagenomes_dir / "download_successful.pickle"
     man_fail = metagenomes_dir / "download_failed.pickle"
     dir_paths = handle_dirs(
         database, ["updates", "index", "signatures", "indexing-failed", "manifests"]
@@ -174,7 +173,6 @@ def run_downloads(
         download_from_wort(
             dir_paths,
             missing_ids,
-            man_succ,
             man_fail,
             timeout,
             retry_failed or not settings.WORT_SKIP_FAILED,
@@ -228,16 +226,15 @@ def get_wort_accessions():
 async def download_from_wort(
     dir_paths,
     sra_ids,
-    man_succ,
     man_fail,
     timeout_seconds,
     retry_failed=False,
     max_downloads=None,
     max_simultaneous=100,
 ):
-    ids_succ = set(load_pickle(man_succ)) if man_succ.exists() else set()
+    ids_in_updates = get_update_accessions(dir_paths["updates"])
     ids_fail = set(load_pickle(man_fail)) if man_fail.exists() else set()
-    sra_ids = sra_ids - ids_succ
+    sra_ids = sra_ids - ids_in_updates
     if not retry_failed:
         sra_ids = list(sra_ids - ids_fail)
     if max_downloads is None and settings.MAX_DOWNLOADS:
@@ -258,17 +255,13 @@ async def download_from_wort(
         connector=conn, trust_env=True, timeout=timeout
     ) as session:
         tasks = [
-            fetch_signature(
-                session, url, target_dir, ids_succ, ids_fail, man_succ, man_fail, lock
-            )
+            fetch_signature(session, url, target_dir, ids_fail, man_fail, lock)
             for url in urls
         ]
         return await asyncio.gather(*tasks, return_exceptions=False)
 
 
-async def fetch_signature(
-    session, url, target_dir, ids_succ, ids_fail, man_succ, man_fail, lock
-):
+async def fetch_signature(session, url, target_dir, ids_fail, man_fail, lock):
     accession = url.split("/")[-1]
     try:
         async with session.get(url, ssl=ssl.SSLContext()) as response:
@@ -286,9 +279,6 @@ async def fetch_signature(
                 await handle.flush()
                 dest = f"{target_dir}/{accession}.sig"
                 await asyncio.to_thread(shutil.move, handle.name, dest)
-            async with lock:
-                ids_succ.add(accession)
-                await asyncio.to_thread(save_pickle, ids_succ, man_succ)
             return {"id": accession, "status": status, "path": dest}
     except Exception:
         LOGGER.exception("Download exception for %s", url)
@@ -306,6 +296,10 @@ def save_pickle(data, file):
 def load_pickle(file):
     with open(file, "rb") as handle:
         return pickle.load(handle)
+
+
+def get_update_accessions(updates_dir):
+    return {sig_path.stem for sig_path in Path(updates_dir).glob("*.sig")}
 
 
 def run_index():
@@ -359,16 +353,6 @@ def run_index():
                     new_files, mani_list, manifest, dir_paths, index_number
                 )
             indexing_ever_failed = indexing_ever_failed or not indexing_succeeded
-        if not indexing_ever_failed:
-            save_pickle(
-                set(),
-                os.path.join(
-                    settings.DATA_DIR,
-                    database,
-                    "metagenomes",
-                    "download_successful.pickle",
-                ),
-            )
     return {"indexes_updated": 1}
 
 

--- a/mgw_api/tests/test_download_maintenance.py
+++ b/mgw_api/tests/test_download_maintenance.py
@@ -1,0 +1,91 @@
+import asyncio
+import pickle
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+from django.test.utils import override_settings
+
+from mgw_api.services.maintenance import download_from_wort
+from mgw_api.services.maintenance import get_update_accessions
+from mgw_api.services.maintenance import run_index
+
+
+class DownloadMaintenanceTests(SimpleTestCase):
+    def test_get_update_accessions_reads_pending_signatures_from_updates_dir(self):
+        with TemporaryDirectory() as tmp_dir:
+            updates_dir = Path(tmp_dir)
+            (updates_dir / "SRR1.sig").write_text("sig", encoding="ascii")
+            (updates_dir / "SRR2.sig").write_text("sig", encoding="ascii")
+            (updates_dir / "README.txt").write_text("ignore", encoding="ascii")
+
+            self.assertEqual(get_update_accessions(updates_dir), {"SRR1", "SRR2"})
+
+    def test_download_from_wort_skips_ids_already_present_in_updates_dir(self):
+        with TemporaryDirectory() as tmp_dir:
+            base_dir = Path(tmp_dir)
+            updates_dir = base_dir / "updates"
+            updates_dir.mkdir()
+            (updates_dir / "SRR1.sig").write_text("sig", encoding="ascii")
+            man_fail = base_dir / "download_failed.pickle"
+            with open(man_fail, "wb") as handle:
+                pickle.dump(set(), handle, protocol=4)
+
+            async def fake_fetch_signature(
+                session, url, target_dir, ids_fail, failed_pickle, lock
+            ):
+                return {"url": url}
+
+            with patch(
+                "mgw_api.services.maintenance.fetch_signature",
+                side_effect=fake_fetch_signature,
+            ) as fetch_mock:
+                asyncio.run(
+                    download_from_wort(
+                        {"updates": updates_dir},
+                        {"SRR1", "SRR2"},
+                        man_fail,
+                        timeout_seconds=1,
+                    )
+                )
+
+        self.assertEqual(fetch_mock.call_count, 1)
+        self.assertEqual(
+            fetch_mock.call_args.args[1],
+            "https://wort.sourmash.bio/v1/view/sra/SRR2",
+        )
+
+    @override_settings(
+        DATA_DIR=Path("/tmp/mgwatch-test-data"),
+        INDEX_MAX_SIGNATURES=100000,
+        INDEX_MIN_ITERATOR=38,
+        DELETE_INDEXED_SIGS=False,
+    )
+    def test_run_index_does_not_touch_download_successful_pickle(self):
+        with TemporaryDirectory() as tmp_dir:
+            data_dir = Path(tmp_dir)
+            database_dir = data_dir / "SRA" / "metagenomes"
+            for name in [
+                "updates",
+                "index",
+                "signatures",
+                "indexing-failed",
+                "manifests",
+            ]:
+                (database_dir / name).mkdir(parents=True, exist_ok=True)
+            (database_dir / "updates" / "SRR1.sig").write_text("sig", encoding="ascii")
+            success_pickle = database_dir / "download_successful.pickle"
+            success_pickle.write_bytes(b"sentinel")
+            manifest = database_dir / "manifest.pickle"
+            with open(manifest, "wb") as handle:
+                pickle.dump([], handle, protocol=4)
+
+            with (
+                override_settings(DATA_DIR=data_dir),
+                patch("mgw_api.services.maintenance.update_index", return_value=0),
+            ):
+                result = run_index()
+
+            self.assertEqual(result, {"indexes_updated": 1})
+            self.assertEqual(success_pickle.read_bytes(), b"sentinel")

--- a/mgw_api/tests/test_watch_maintenance.py
+++ b/mgw_api/tests/test_watch_maintenance.py
@@ -1,0 +1,122 @@
+import tempfile
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.core.files.base import ContentFile
+from django.test import TestCase
+from django.test import override_settings
+
+from mgw.settings import LOGGER
+from mgw_api.models import Fasta
+from mgw_api.models import Result
+from mgw_api.models import Signature
+from mgw_api.services.maintenance import run_watch
+
+TEST_MEDIA_ROOT = tempfile.mkdtemp()
+
+
+@override_settings(MEDIA_ROOT=TEST_MEDIA_ROOT)
+class RunWatchTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="owner", password="testpass123")
+        self.fasta = Fasta.objects.create(
+            user=self.user,
+            name="example",
+            size=1,
+            processed=True,
+            status="Complete",
+            result_pk=None,
+            file="user_1/example.fa",
+        )
+
+        self.bad_signature = Signature.objects.create(
+            user=self.user,
+            name="bad-watch",
+            fasta=self.fasta,
+            size=1,
+        )
+        self.bad_signature.file.save(
+            "bad.sig",
+            ContentFile(b"bad-signature"),
+            save=True,
+        )
+        self.good_signature = Signature.objects.create(
+            user=self.user,
+            name="good-watch",
+            fasta=self.fasta,
+            size=1,
+        )
+        self.good_signature.file.save(
+            "good.sig",
+            ContentFile(b"good-signature"),
+            save=True,
+        )
+
+        self.bad_result = Result.objects.create(
+            user=self.user,
+            name="bad-watch",
+            signature=self.bad_signature,
+            num_results=1,
+            kmer=[21],
+            database=["SRA"],
+            containment=0.1,
+            is_watched=True,
+        )
+        self.bad_result.file.save(
+            "bad.csv",
+            ContentFile(b"col\nold\n"),
+            save=True,
+        )
+        self.good_result = Result.objects.create(
+            user=self.user,
+            name="good-watch",
+            signature=self.good_signature,
+            num_results=1,
+            kmer=[21],
+            database=["SRA"],
+            containment=0.1,
+            is_watched=True,
+        )
+        self.good_result.file.save(
+            "good.csv",
+            ContentFile(b"col\nold\n"),
+            save=True,
+        )
+
+    def test_run_watch_continues_after_per_watch_failure(self):
+        call_order = []
+
+        def fake_search_watch(name, user_id, watch_pk):
+            call_order.append(watch_pk)
+            if watch_pk == self.bad_result.pk:
+                raise FileNotFoundError("missing signature")
+            return self.good_result
+
+        with self.assertLogs(LOGGER.name, level="ERROR") as captured_logs:
+            with (
+                patch(
+                    "mgw_api.services.maintenance.search_watch",
+                    side_effect=fake_search_watch,
+                ),
+                patch(
+                    "mgw_api.services.maintenance.compare_results", return_value=True
+                ),
+            ):
+                result = run_watch()
+
+        self.assertEqual(call_order, [self.bad_result.pk, self.good_result.pk])
+        self.assertEqual(
+            result,
+            {
+                "processed_watches": 1,
+                "failed_watches": 1,
+            },
+        )
+        self.bad_signature.refresh_from_db()
+        self.good_signature.refresh_from_db()
+        self.assertTrue(self.bad_signature.submitted)
+        self.assertTrue(self.good_signature.submitted)
+        self.assertIn(
+            "Watch run failed for result_pk=",
+            "\n".join(captured_logs.output),
+        )


### PR DESCRIPTION
## Summary

This is PR 5 in the split Celery/workflow stack.

- Removes the separate successful-download pickle state from the Wort update flow.
- Uses the pending `updates/` signatures directory as the source of truth for downloaded-but-not-indexed signatures.
- Keeps failed-download state separate.
- Adds regression tests for pending update detection, download skipping, and watch failure handling.

## Stack

Base: `split/04-search-status-ui`
Head: `split/05-index-update-state-cleanup`

## Validation

- Pre-commit hooks passed when committed.
- `python -m py_compile` passed for touched maintenance/test modules during the split.