### PR TITLE
Split 06: add configurable index batch size

### DIFF
--- a/mgw_api/management/commands/create_index.py
+++ b/mgw_api/management/commands/create_index.py
@@ -6,6 +6,15 @@ from mgw_api.tasks import run_index_task
 
 
 class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument("-n", "--index-max-signatures", default=None, type=int)
+
     def handle(self, *args, **kwargs):
-        wait_for_task(run_index_task, queue=INDEX_QUEUE)
+        wait_for_task(
+            run_index_task,
+            kwargs={
+                "index_max_signatures": kwargs["index_max_signatures"],
+            },
+            queue=INDEX_QUEUE,
+        )
         self.stdout.write(self.style.SUCCESS("Index update completed"))

--- a/mgw_api/services/maintenance.py
+++ b/mgw_api/services/maintenance.py
@@ -302,7 +302,7 @@ def get_update_accessions(updates_dir):
     return {sig_path.stem for sig_path in Path(updates_dir).glob("*.sig")}
 
 
-def run_index():
+def run_index(*, index_max_signatures=None):
     tmp_dir = settings.DATA_DIR / "tmp"
     os.makedirs(tmp_dir, exist_ok=True)
     with tempfile.TemporaryDirectory(prefix="mgwatch-index-", dir=tmp_dir) as work_dir:
@@ -317,7 +317,8 @@ def run_index():
         mani_list = get_manifest(manifest)
         last_sig_files, last_num, has_existing_index = get_last_index(dir_paths)
         delete_indexed_sigs = getattr(settings, "DELETE_INDEXED_SIGS", False)
-        new_sig_files = glob.glob(os.path.join(dir_paths["updates"], "*.sig"))
+        max_signatures = index_max_signatures or settings.INDEX_MAX_SIGNATURES
+        new_sig_files = sorted(glob.glob(os.path.join(dir_paths["updates"], "*.sig")))
         if not new_sig_files:
             return {"indexes_updated": 0}
         reuse_last_index = can_reuse_last_index(last_sig_files, has_existing_index)
@@ -328,9 +329,7 @@ def run_index():
             sig_files = new_sig_files
             start_index_number = last_num + 1
         indexing_ever_failed = False
-        for idx_offset, new_files in enumerate(
-            batched(sig_files, n=settings.INDEX_MAX_SIGNATURES), 0
-        ):
+        for idx_offset, new_files in enumerate(batched(sig_files, n=max_signatures), 0):
             write_signature_list(new_files, sig_list)
             index_number = start_index_number + idx_offset
             retvals = [
@@ -341,7 +340,7 @@ def run_index():
             delete_after_indexing = (
                 indexing_succeeded
                 and delete_indexed_sigs
-                and len(new_files) == settings.INDEX_MAX_SIGNATURES
+                and len(new_files) == max_signatures
             )
             if delete_after_indexing:
                 delete_files(new_files)

--- a/mgw_api/tests/test_create_index.py
+++ b/mgw_api/tests/test_create_index.py
@@ -1,11 +1,14 @@
 import pickle
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from django.test import SimpleTestCase
+from django.test.utils import override_settings
 
 from mgw_api.services.maintenance import can_reuse_last_index
 from mgw_api.services.maintenance import get_last_index
+from mgw_api.services.maintenance import run_index
 
 
 class CreateIndexServiceTests(SimpleTestCase):
@@ -42,3 +45,51 @@ class CreateIndexServiceTests(SimpleTestCase):
             )
             self.assertFalse(can_reuse_last_index([], True))
             self.assertTrue(can_reuse_last_index([], False))
+
+    @override_settings(
+        INDEX_MAX_SIGNATURES=100000,
+        INDEX_MIN_ITERATOR=38,
+        DELETE_INDEXED_SIGS=False,
+    )
+    def test_run_index_uses_override_for_max_index_size(self):
+        with TemporaryDirectory() as tmp_dir:
+            data_dir = Path(tmp_dir)
+            metagenomes_dir = data_dir / "SRA" / "metagenomes"
+            for name in [
+                "updates",
+                "index",
+                "signatures",
+                "indexing-failed",
+                "manifests",
+            ]:
+                (metagenomes_dir / name).mkdir(parents=True, exist_ok=True)
+            for accession in ["SRR1", "SRR2", "SRR3"]:
+                (metagenomes_dir / "updates" / f"{accession}.sig").write_text(
+                    "sig", encoding="ascii"
+                )
+            with open(metagenomes_dir / "manifest.pickle", "wb") as handle:
+                pickle.dump([], handle, protocol=4)
+
+            written_lists = []
+
+            def capture_signature_list(sig_file_names, output_file):
+                written_lists.append(list(sig_file_names))
+
+            with (
+                override_settings(DATA_DIR=data_dir),
+                patch(
+                    "mgw_api.services.maintenance.write_signature_list",
+                    side_effect=capture_signature_list,
+                ),
+                patch("mgw_api.services.maintenance.update_index", return_value=0),
+                patch("mgw_api.services.maintenance.move_files"),
+                patch("mgw_api.services.maintenance.update_manifests"),
+            ):
+                result = run_index(index_max_signatures=2)
+
+        self.assertEqual(result, {"indexes_updated": 1})
+        self.assertEqual(len(written_lists), 2)
+        self.assertEqual(
+            [Path(path).name for path in written_lists[0]], ["SRR1.sig", "SRR2.sig"]
+        )
+        self.assertEqual([Path(path).name for path in written_lists[1]], ["SRR3.sig"])


### PR DESCRIPTION
## Summary

This is PR 6 in the split Celery/workflow stack.

- Adds an `--index-max-signatures` override to the index management command path.
- Threads the override through the Celery index task into `run_index()`.
- Sorts pending signature files before batching so batch behavior is deterministic.
- Adds tests for multi-batch index creation behavior.

## Stack

Base: `split/05-index-update-state-cleanup`
Head: `split/06-index-batch-size-config`

## Validation

- Pre-commit hooks passed when committed.
- `python -m py_compile` passed for touched command/service/test modules during the split.