### PR TITLE
Split 09: add Wort state bundle tooling

### DIFF
--- a/mgw_api/tests/test_wort_state_bundle.py
+++ b/mgw_api/tests/test_wort_state_bundle.py
@@ -1,0 +1,118 @@
+import importlib.util
+import pickle
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "wort-state-bundle.py"
+SPEC = importlib.util.spec_from_file_location("wort_state_bundle", MODULE_PATH)
+wort_state_bundle = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = wort_state_bundle
+SPEC.loader.exec_module(wort_state_bundle)
+
+
+class WortStateBundleTests(TestCase):
+    def make_work_metagenomes(self, root: Path):
+        work_dir = root / "work" / "data" / "backend-data"
+        metagenomes = work_dir / "SRA" / "metagenomes"
+        for path in (
+            metagenomes / "updates",
+            metagenomes / "index",
+            metagenomes / "signatures",
+            metagenomes / "indexing-failed",
+            metagenomes / "manifests",
+        ):
+            path.mkdir(parents=True, exist_ok=True)
+        return work_dir, metagenomes
+
+    def test_prepare_bundle_copies_state_files_and_writes_builder_state(self):
+        with TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            work_dir, metagenomes = self.make_work_metagenomes(tmp_path)
+            with open(metagenomes / "manifest.pickle", "wb") as handle:
+                pickle.dump(["SRR1", "SRR2"], handle, protocol=4)
+            with open(metagenomes / "download_failed.pickle", "wb") as handle:
+                pickle.dump({"SRR9"}, handle, protocol=4)
+            with open(metagenomes / "manifests" / "db41.pickle", "wb") as handle:
+                pickle.dump(["SRR1", "SRR2"], handle, protocol=4)
+            (metagenomes / "updates" / "SRR3.sig").write_text("sig", encoding="ascii")
+            (metagenomes / "indexing-failed" / "SRR8.sig").write_text(
+                "sig", encoding="ascii"
+            )
+
+            bundle_dir = tmp_path / "bundle"
+            wort_state_bundle.prepare_bundle(bundle_dir=bundle_dir, work_dir=work_dir)
+
+            bundle_metagenomes = bundle_dir / "SRA" / "metagenomes"
+            with open(bundle_metagenomes / "manifest.pickle", "rb") as handle:
+                self.assertEqual(pickle.load(handle), ["SRR1", "SRR2"])
+            with open(bundle_metagenomes / "download_failed.pickle", "rb") as handle:
+                self.assertEqual(pickle.load(handle), {"SRR9"})
+            with open(bundle_metagenomes / "manifests" / "db41.pickle", "rb") as handle:
+                self.assertEqual(pickle.load(handle), ["SRR1", "SRR2"])
+            self.assertTrue((bundle_metagenomes / "updates" / "SRR3.sig").exists())
+            self.assertTrue(
+                (bundle_metagenomes / "indexing-failed" / "SRR8.sig").exists()
+            )
+
+            state = (bundle_dir / "builder-state.json").read_text(encoding="utf-8")
+
+        self.assertIn('"next_index_number": 42', state)
+        self.assertIn('"remaining_accessions": 1', state)
+        self.assertIn('"manifest_entries": 2', state)
+
+    def test_apply_output_merges_new_indexes_and_clears_stale_updates(self):
+        with TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            work_dir, work_metagenomes = self.make_work_metagenomes(tmp_path)
+            (work_metagenomes / "updates" / "SRR3.sig").write_text(
+                "old", encoding="ascii"
+            )
+            (work_metagenomes / "index" / "21mers-db41.rocksdb").mkdir()
+            (work_metagenomes / "index" / "21mers-db41.rocksdb" / "OLD").write_text(
+                "stale", encoding="ascii"
+            )
+
+            output_dir = tmp_path / "builder-output"
+            _, output_metagenomes = self.make_work_metagenomes(output_dir)
+            with open(output_metagenomes / "manifest.pickle", "wb") as handle:
+                pickle.dump(["SRR1", "SRR2", "SRR3"], handle, protocol=4)
+            with open(output_metagenomes / "download_failed.pickle", "wb") as handle:
+                pickle.dump({"SRR9"}, handle, protocol=4)
+            with open(output_metagenomes / "manifests" / "db41.pickle", "wb") as handle:
+                pickle.dump(["SRR3"], handle, protocol=4)
+            (output_metagenomes / "index" / "21mers-db41.rocksdb").mkdir(
+                parents=True, exist_ok=True
+            )
+            (
+                output_metagenomes / "index" / "21mers-db41.rocksdb" / "CURRENT"
+            ).write_text("fresh", encoding="ascii")
+            (output_metagenomes / "signatures" / "SRR3.sig").write_text(
+                "sig", encoding="ascii"
+            )
+            (output_metagenomes / "updates" / "SRR4.sig").write_text(
+                "sig", encoding="ascii"
+            )
+
+            wort_state_bundle.apply_output(
+                builder_output_dir=output_dir / "work" / "data" / "backend-data",
+                work_dir=work_dir,
+            )
+
+            self.assertFalse((work_metagenomes / "updates" / "SRR3.sig").exists())
+            self.assertTrue((work_metagenomes / "updates" / "SRR4.sig").exists())
+            self.assertTrue((work_metagenomes / "signatures" / "SRR3.sig").exists())
+            self.assertFalse(
+                (work_metagenomes / "index" / "21mers-db41.rocksdb" / "OLD").exists()
+            )
+            self.assertTrue(
+                (
+                    work_metagenomes / "index" / "21mers-db41.rocksdb" / "CURRENT"
+                ).exists()
+            )
+            with open(work_metagenomes / "manifest.pickle", "rb") as handle:
+                self.assertEqual(pickle.load(handle), ["SRR1", "SRR2", "SRR3"])
+            with open(work_metagenomes / "download_failed.pickle", "rb") as handle:
+                self.assertEqual(pickle.load(handle), {"SRR9"})

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -19,8 +19,20 @@ corresponding rocksdb indexes, records progress in `builder-state.json`, and del
 indexed signatures by default to keep disk usage bounded while still allowing safe
 stop-and-resume runs.
 
+Prepare/apply builder state bundles:
+
+```bash
+$ python scripts/wort-state-bundle.py prepare --bundle-dir /tmp/wort-state
+$ python scripts/wort-state-bundle.py apply --builder-output-dir /tmp/wort-build
+```
+
+`prepare` exports the current `work/data/backend-data/SRA/metagenomes` state into a
+portable bundle for remote standalone runs. `apply` merges a completed standalone
+builder output directory back into the local `work/` tree.
+
 Testing:
 
 ```
 $ python -m unittest mgw_api.tests.test_wort_index_builder
+$ python -m unittest mgw_api.tests.test_wort_state_bundle
 ```

--- a/scripts/wort-state-bundle.py
+++ b/scripts/wort-state-bundle.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Prepare and apply state bundles for wort-standalone-index-builder."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pickle
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_WORK_DIR = REPO_ROOT / "work" / "data" / "backend-data"
+
+
+@dataclass
+class MetagenomePaths:
+    root: Path
+    sra: Path
+    metagenomes: Path
+    updates: Path
+    index: Path
+    signatures: Path
+    indexing_failed: Path
+    manifests: Path
+    manifest: Path
+    failed_downloads: Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Prepare a standalone Wort index builder state bundle or apply a "
+            "builder output back into the local work directory."
+        )
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    prepare = subparsers.add_parser(
+        "prepare",
+        help="Copy the current work state into a portable bundle directory.",
+    )
+    prepare.add_argument("--bundle-dir", required=True, type=Path)
+    prepare.add_argument(
+        "--work-dir",
+        type=Path,
+        default=DEFAULT_WORK_DIR,
+        help=(
+            "Path to backend-data/, SRA/, or SRA/metagenomes/. Defaults to "
+            "work/data/backend-data."
+        ),
+    )
+
+    apply_parser = subparsers.add_parser(
+        "apply",
+        help="Merge a standalone builder output directory back into work/.",
+    )
+    apply_parser.add_argument("--builder-output-dir", required=True, type=Path)
+    apply_parser.add_argument(
+        "--work-dir",
+        type=Path,
+        default=DEFAULT_WORK_DIR,
+        help=(
+            "Path to backend-data/, SRA/, or SRA/metagenomes/. Defaults to "
+            "work/data/backend-data."
+        ),
+    )
+
+    return parser.parse_args()
+
+
+def resolve_metagenome_paths(base_dir: Path) -> MetagenomePaths:
+    base_dir = base_dir.resolve()
+    if base_dir.name == "metagenomes":
+        metagenomes = base_dir
+    elif base_dir.name == "SRA":
+        metagenomes = base_dir / "metagenomes"
+    else:
+        metagenomes = base_dir / "SRA" / "metagenomes"
+
+    sra = metagenomes.parent
+    return MetagenomePaths(
+        root=sra.parent,
+        sra=sra,
+        metagenomes=metagenomes,
+        updates=metagenomes / "updates",
+        index=metagenomes / "index",
+        signatures=metagenomes / "signatures",
+        indexing_failed=metagenomes / "indexing-failed",
+        manifests=metagenomes / "manifests",
+        manifest=metagenomes / "manifest.pickle",
+        failed_downloads=metagenomes / "download_failed.pickle",
+    )
+
+
+def ensure_bundle_dirs(paths: MetagenomePaths) -> None:
+    for dir_path in (
+        paths.updates,
+        paths.index,
+        paths.signatures,
+        paths.indexing_failed,
+        paths.manifests,
+    ):
+        dir_path.mkdir(parents=True, exist_ok=True)
+
+
+def copy_file(src: Path, dst: Path) -> bool:
+    if not src.exists():
+        return False
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dst)
+    return True
+
+
+def copy_sig_files(src_dir: Path, dst_dir: Path) -> int:
+    if not src_dir.exists():
+        return 0
+    dst_dir.mkdir(parents=True, exist_ok=True)
+    copied = 0
+    for sig_path in sorted(src_dir.glob("*.sig")):
+        shutil.copy2(sig_path, dst_dir / sig_path.name)
+        copied += 1
+    return copied
+
+
+def copy_manifest_pickles(src_dir: Path, dst_dir: Path) -> int:
+    if not src_dir.exists():
+        return 0
+    dst_dir.mkdir(parents=True, exist_ok=True)
+    copied = 0
+    for manifest_path in sorted(src_dir.glob("db*.pickle")):
+        shutil.copy2(manifest_path, dst_dir / manifest_path.name)
+        copied += 1
+    return copied
+
+
+def load_pickle(path: Path, default):
+    if not path.exists():
+        return default
+    with path.open("rb") as handle:
+        return pickle.load(handle)
+
+
+def save_json(path: Path, data: dict) -> None:
+    tmp_path = path.with_name(f".{path.name}.tmp")
+    with tmp_path.open("w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    os.replace(tmp_path, path)
+
+
+def list_db_numbers(manifests_dir: Path) -> list[int]:
+    numbers = []
+    if not manifests_dir.exists():
+        return numbers
+    for path in manifests_dir.glob("db*.pickle"):
+        try:
+            numbers.append(int(path.stem[2:]))
+        except ValueError:
+            continue
+    return sorted(numbers)
+
+
+def determine_next_index_number(paths: MetagenomePaths) -> int:
+    numbers = list_db_numbers(paths.manifests)
+    if not numbers:
+        return 38
+    return max(numbers) + 1
+
+
+def build_builder_state(paths: MetagenomePaths) -> dict:
+    manifest_ids = load_pickle(paths.manifest, [])
+    failed_downloads = sorted(load_pickle(paths.failed_downloads, set()))
+    return {
+        "active_batch": None,
+        "batches_completed": len(list_db_numbers(paths.manifests)),
+        "failed_downloads": failed_downloads,
+        "manifest_entries": len(manifest_ids),
+        "next_index_number": determine_next_index_number(paths),
+        "remaining_accessions": len(
+            sorted(path.stem for path in paths.updates.glob("*.sig"))
+        ),
+    }
+
+
+def prepare_bundle(bundle_dir: Path, work_dir: Path) -> None:
+    source_paths = resolve_metagenome_paths(work_dir)
+    bundle_paths = resolve_metagenome_paths(bundle_dir / "SRA" / "metagenomes")
+    ensure_bundle_dirs(bundle_paths)
+
+    copy_file(source_paths.manifest, bundle_paths.manifest)
+    copy_file(source_paths.failed_downloads, bundle_paths.failed_downloads)
+    copied_manifests = copy_manifest_pickles(
+        source_paths.manifests, bundle_paths.manifests
+    )
+    copied_updates = copy_sig_files(source_paths.updates, bundle_paths.updates)
+    copied_failed = copy_sig_files(
+        source_paths.indexing_failed, bundle_paths.indexing_failed
+    )
+
+    save_json(bundle_dir / "builder-state.json", build_builder_state(source_paths))
+
+    print(f"Prepared bundle in {bundle_dir}")
+    print(f"Copied {copied_manifests} manifest files")
+    print(f"Copied {copied_updates} queued update signatures")
+    print(f"Copied {copied_failed} indexing-failed signatures")
+
+
+def remove_matching_signatures(directory: Path, accession_names: set[str]) -> int:
+    removed = 0
+    if not directory.exists():
+        return removed
+    for accession in sorted(accession_names):
+        sig_path = directory / f"{accession}.sig"
+        if sig_path.exists():
+            sig_path.unlink()
+            removed += 1
+    return removed
+
+
+def replace_tree(src: Path, dst: Path) -> None:
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.copytree(src, dst)
+
+
+def apply_output(builder_output_dir: Path, work_dir: Path) -> None:
+    source_paths = resolve_metagenome_paths(builder_output_dir)
+    work_paths = resolve_metagenome_paths(work_dir)
+    ensure_bundle_dirs(work_paths)
+
+    copied_indexes = 0
+    if source_paths.index.exists():
+        for index_dir in sorted(source_paths.index.glob("*.rocksdb")):
+            replace_tree(index_dir, work_paths.index / index_dir.name)
+            copied_indexes += 1
+
+    copied_manifests = copy_manifest_pickles(
+        source_paths.manifests, work_paths.manifests
+    )
+    replaced_manifest = copy_file(source_paths.manifest, work_paths.manifest)
+    replaced_failed_downloads = copy_file(
+        source_paths.failed_downloads, work_paths.failed_downloads
+    )
+
+    copied_updates = copy_sig_files(source_paths.updates, work_paths.updates)
+    copied_signatures = copy_sig_files(source_paths.signatures, work_paths.signatures)
+    copied_failed = copy_sig_files(
+        source_paths.indexing_failed, work_paths.indexing_failed
+    )
+
+    indexed_accessions = set()
+    if source_paths.manifests.exists():
+        for manifest_path in sorted(source_paths.manifests.glob("db*.pickle")):
+            indexed_accessions.update(load_pickle(manifest_path, []))
+    removed_updates = remove_matching_signatures(work_paths.updates, indexed_accessions)
+
+    print(f"Applied builder output from {builder_output_dir}")
+    print(f"Copied {copied_indexes} rocksdb indexes")
+    print(f"Copied {copied_manifests} manifest batch files")
+    print(f"Replaced aggregate manifest: {'yes' if replaced_manifest else 'no'}")
+    print(
+        f"Replaced failed-download state: {'yes' if replaced_failed_downloads else 'no'}"
+    )
+    print(f"Copied {copied_updates} update signatures")
+    print(f"Copied {copied_signatures} retained signatures")
+    print(f"Copied {copied_failed} indexing-failed signatures")
+    print(f"Removed {removed_updates} stale update signatures")
+
+
+def main() -> int:
+    args = parse_args()
+    if args.command == "prepare":
+        prepare_bundle(bundle_dir=args.bundle_dir.resolve(), work_dir=args.work_dir)
+        return 0
+    if args.command == "apply":
+        apply_output(
+            builder_output_dir=args.builder_output_dir.resolve(),
+            work_dir=args.work_dir,
+        )
+        return 0
+    raise ValueError(f"unsupported command '{args.command}'")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This is PR 9 in the split Celery/workflow stack.

- Adds `scripts/wort-state-bundle.py` to prepare current Wort index state for remote standalone builds.
- Adds apply-mode support to merge completed standalone builder output back into local `work/` state.
- Documents prepare/apply usage in `scripts/README.md`.
- Adds tests for state bundle preparation and output application.

## Stack

Base: `split/08-standalone-hpc-builder`
Head: `split/09-hpc-state-bundles`

## Validation

- Pre-commit hooks passed when committed.
- `python -m py_compile` passed for the bundle script and tests.
- Final-stack focused validation included `python -m unittest mgw_api.tests.test_wort_state_bundle`.