### PR TITLE
Reduce sensitive logging

### DIFF
--- a/mgw_api/functions.py
+++ b/mgw_api/functions.py
@@ -63,7 +63,11 @@ def get_branchwater_table(result, max_rows=None):
         result.file.path, index_col="match_name", nrows=max_rows, dtype=data_types
     )
     branchwater_subset = branchwater_results[branchwater_columns_for_output]
-    LOGGER.info(f"{branchwater_subset}")
+    LOGGER.debug(
+        "Loaded branchwater results: rows=%s columns=%s",
+        len(branchwater_subset),
+        list(branchwater_subset.columns),
+    )
     return branchwater_subset
 
 
@@ -134,9 +138,12 @@ def add_sra_metadata(branchwater_results):
     sra_metadata = get_sra_fields(sra_accessions, sra_columns)
     results_with_metadata = branchwater_results.join(sra_metadata, on="sra_accession")
     results_with_metadata = results_with_metadata.reset_index(drop=True)
-    LOGGER.info(f"branchwater_results: {branchwater_results}")
-    LOGGER.info(f"sra_metadata: {sra_metadata}")
-    LOGGER.info(f"joined: {results_with_metadata}")
+    LOGGER.debug(
+        "Joined branchwater results with SRA metadata: result_rows=%s metadata_rows=%s joined_rows=%s",
+        len(branchwater_results),
+        len(sra_metadata),
+        len(results_with_metadata),
+    )
     return results_with_metadata
 
 
@@ -180,8 +187,7 @@ def get_sra_fields(sra_accessions, fields):
         )
     mongo.close()
     sra_metadata = pd.DataFrame(results)
-    pd.set_option("display.max_columns", None)
-    LOGGER.info(f"get_sra_fields: {sra_metadata}")
+    LOGGER.debug("Loaded SRA metadata rows=%s fields=%s", len(sra_metadata), fields)
     sra_metadata.set_index("_id", inplace=True)
     missing_columns = set(fields) - set(sra_metadata.columns)
     if len(missing_columns) > 0:

--- a/mgw_api/models.py
+++ b/mgw_api/models.py
@@ -32,14 +32,12 @@ def validate_fasta_content(fieldfile):
         # Do actual validation. This is not exhaustive, it's only checking the
         # first couple of lines as a sanity check.
         if not re.match(r"^>", header):
-            LOGGER.error(f"header: {header}")
-            LOGGER.error(f"seq: {seq}")
+            LOGGER.warning("Invalid FASTA upload rejected: missing header marker.")
             raise ValidationError(
                 "File does not start with '>' character, invalid FASTA format."
             )
         elif not re.match(r"^[ACGTRYSWKMBDHVN.-]+$", seq, flags=re.IGNORECASE):
-            LOGGER.error(f"header: {header}")
-            LOGGER.error(f"seq: {seq}")
+            LOGGER.warning("Invalid FASTA upload rejected: non-IUPAC sequence data.")
             raise ValidationError(
                 "Sequence contains non-IUPAC characters, invalid FASTA format."
             )

--- a/mgw_api/services/exceptions.py
+++ b/mgw_api/services/exceptions.py
@@ -9,13 +9,24 @@ class LockTimeoutError(Exception):
 class ExternalCommandError(Exception):
     """Raised when an external command fails."""
 
+    max_output_length = 1000
+
     def __init__(self, command, returncode, stdout="", stderr=""):
         self.command = command
         self.returncode = returncode
         self.stdout = stdout
         self.stderr = stderr
+        executable = command[0] if command else "<empty>"
+        output = self._summarize_output(stderr or stdout)
         message = (
-            f"Command failed with exit code {returncode}: {' '.join(command)}. "
-            f"{stderr or stdout}".strip()
+            f"Command failed with exit code {returncode}: executable={executable}. "
+            f"{output}".strip()
         )
         super().__init__(message)
+
+    def _summarize_output(self, output):
+        if not output:
+            return "No command output captured."
+        if len(output) <= self.max_output_length:
+            return output
+        return output[: self.max_output_length] + "... [truncated]"

--- a/mgw_api/services/jobs.py
+++ b/mgw_api/services/jobs.py
@@ -215,12 +215,16 @@ def mark_job_progress(job, *, message, current, total):
 
 
 def mark_job_failed(job, exc):
+    error_message = str(exc)
     update_job(
         job,
         state=Job.State.FAILED,
         status_message="Failed",
-        error_message=str(exc),
-        failure_details={"error": str(exc)},
+        error_message=error_message,
+        failure_details={
+            "error": error_message[:1000],
+            "error_type": exc.__class__.__name__,
+        },
         finished=True,
     )
     sync_fasta_from_job(job)

--- a/mgw_api/services/processes.py
+++ b/mgw_api/services/processes.py
@@ -6,9 +6,14 @@ from mgw.settings import LOGGER
 from .exceptions import ExternalCommandError
 
 
+def _describe_command(command):
+    executable = command[0] if command else "<empty>"
+    return "executable=%s args=%s" % (executable, max(len(command) - 1, 0))
+
+
 def run_command(command, *, timeout=None, cwd=None):
     start = time.monotonic()
-    LOGGER.info("Running external command: %s", " ".join(command))
+    LOGGER.info("Running external command: %s", _describe_command(command))
     result = subprocess.run(
         command,
         capture_output=True,
@@ -22,7 +27,7 @@ def run_command(command, *, timeout=None, cwd=None):
         "Finished external command rc=%s duration=%.2fs: %s",
         result.returncode,
         duration,
-        " ".join(command),
+        _describe_command(command),
     )
     if result.returncode != 0:
         raise ExternalCommandError(


### PR DESCRIPTION
## Summary
- Stop logging raw FASTA header/sequence content during validation failures.
- Replace DataFrame dumps with row/column count logging for search result metadata joins.
- Redact external command logging and truncate stored command failure details.

## Why
Raw sequence content, metadata rows, command arguments, and long command output can contain sensitive operational or user-provided data. This keeps normal logs useful without exposing unnecessary detail.

Closes #226

## Verification
- `git diff --check main..HEAD`
- `python -m compileall mgw mgw_api`
- `./scripts/run-tests.sh` passed: 33 tests