### PR TITLE
Harden FASTA upload validation

### DIFF
--- a/mgw/settings.py
+++ b/mgw/settings.py
@@ -65,6 +65,9 @@ env = environ.Env(
     CELERY_TASK_RESULT_TIMEOUT=(int, 60 * 60 * 6),
     CELERY_LOCK_TIMEOUT=(int, 60 * 60 * 6),
     CELERY_LOCK_BLOCKING_TIMEOUT=(int, 60),
+    DATA_UPLOAD_MAX_MEMORY_SIZE=(int, 10 * 1024 * 1024),
+    FILE_UPLOAD_MAX_MEMORY_SIZE=(int, 10 * 1024 * 1024),
+    MAX_FASTA_UPLOAD_SIZE=(int, 50 * 1024 * 1024),
 )
 
 environ.Env.read_env(BASE_DIR / "vars.env")
@@ -77,6 +80,9 @@ MGW_URL = env("MGW_URL")
 
 # The maximum number of search results to provide
 MAX_SEARCH_RESULTS = env("MAX_SEARCH_RESULTS")
+DATA_UPLOAD_MAX_MEMORY_SIZE = env("DATA_UPLOAD_MAX_MEMORY_SIZE")
+FILE_UPLOAD_MAX_MEMORY_SIZE = env("FILE_UPLOAD_MAX_MEMORY_SIZE")
+MAX_FASTA_UPLOAD_SIZE = env("MAX_FASTA_UPLOAD_SIZE")
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = env("SECRET_KEY")

--- a/mgw_api/migrations/0034_alter_fasta_file_upload_validation.py
+++ b/mgw_api/migrations/0034_alter_fasta_file_upload_validation.py
@@ -1,0 +1,24 @@
+# Generated manually for upload validation hardening.
+
+import mgw_api.models
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("mgw_api", "0033_job"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="fasta",
+            name="file",
+            field=models.FileField(
+                upload_to=mgw_api.models.user_directory_path,
+                validators=[
+                    mgw_api.models.validate_fasta_extension,
+                    mgw_api.models.validate_fasta_content,
+                ],
+            ),
+        ),
+    ]

--- a/mgw_api/models.py
+++ b/mgw_api/models.py
@@ -1,50 +1,101 @@
 import gzip
-import io
 import re
 from datetime import datetime
 from functools import partial
 from pathlib import Path
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
-from django.core.validators import FileExtensionValidator
 from django.db import models
 from django.db.models import Q
 
 from mgw.settings import LOGGER
 
+FASTA_EXTENSIONS = (".fa", ".fasta", ".fsa", ".fna")
+FASTA_GZIP_EXTENSIONS = tuple(f"{extension}.gz" for extension in FASTA_EXTENSIONS)
+FASTA_SEQUENCE_RE = re.compile(r"^[ACGTRYSWKMBDHVN.-]+$", flags=re.IGNORECASE)
+
+
+def _filename(fieldfile):
+    return Path(getattr(fieldfile, "name", "")).name.lower()
+
+
+def validate_fasta_extension(fieldfile):
+    filename = _filename(fieldfile)
+    allowed_extensions = FASTA_EXTENSIONS + FASTA_GZIP_EXTENSIONS
+    if not filename.endswith(allowed_extensions):
+        raise ValidationError(
+            "Unsupported file extension. Use FASTA files ending in .fa, .fasta, "
+            ".fsa, .fna, or their .gz variants."
+        )
+
+
+def _reset_file(fieldfile):
+    if hasattr(fieldfile, "seek"):
+        fieldfile.seek(0)
+
+
+def _iter_fasta_lines(fieldfile):
+    if _filename(fieldfile).endswith(".gz"):
+        with gzip.GzipFile(fileobj=fieldfile, mode="rb") as fasta_file:
+            for line in fasta_file:
+                yield line
+    else:
+        for line in fieldfile:
+            yield line
+
 
 def validate_fasta_content(fieldfile):
-    # check if first two lines are in fasta format
+    upload_size = getattr(fieldfile, "size", None)
+    if upload_size and upload_size > settings.MAX_FASTA_UPLOAD_SIZE:
+        raise ValidationError("Uploaded FASTA file is larger than the allowed limit.")
+
+    saw_header = False
+    saw_sequence = False
+    decompressed_bytes = 0
     try:
-        if Path(fieldfile.path).suffix == ".gz":
-            # Input file is gzipped. Might be in memory so we need to read
-            # the actual contents and decompress them
-            fasta = gzip.decompress(fieldfile.read()).decode("utf-8")
-            fasta_io = io.StringIO(fasta)
-
-            header = fasta_io.readline().strip()
-            seq = fasta_io.readline().strip()
-        else:
-            header = fieldfile.readline().decode("utf-8").strip()
-            seq = fieldfile.readline().decode("utf-8").strip()
-
-        # Do actual validation. This is not exhaustive, it's only checking the
-        # first couple of lines as a sanity check.
-        if not re.match(r"^>", header):
-            LOGGER.error(f"header: {header}")
-            LOGGER.error(f"seq: {seq}")
+        _reset_file(fieldfile)
+        for raw_line in _iter_fasta_lines(fieldfile):
+            decompressed_bytes += len(raw_line)
+            if decompressed_bytes > settings.MAX_FASTA_UPLOAD_SIZE:
+                raise ValidationError(
+                    "Uploaded FASTA content is larger than the allowed limit."
+                )
+            if isinstance(raw_line, bytes):
+                line = raw_line.decode("utf-8").strip()
+            else:
+                line = raw_line.strip()
+            if not line:
+                continue
+            if line.startswith(">"):
+                saw_header = True
+                continue
+            if not saw_header:
+                LOGGER.warning("Invalid FASTA upload rejected: missing header marker.")
+                raise ValidationError(
+                    "File does not start with '>' character, invalid FASTA format."
+                )
+            if not FASTA_SEQUENCE_RE.match(line):
+                LOGGER.warning(
+                    "Invalid FASTA upload rejected: non-IUPAC sequence data."
+                )
+                raise ValidationError(
+                    "Sequence contains non-IUPAC characters, invalid FASTA format."
+                )
+            saw_sequence = True
+        if not saw_header:
             raise ValidationError(
                 "File does not start with '>' character, invalid FASTA format."
             )
-        elif not re.match(r"^[ACGTRYSWKMBDHVN.-]+$", seq, flags=re.IGNORECASE):
-            LOGGER.error(f"header: {header}")
-            LOGGER.error(f"seq: {seq}")
-            raise ValidationError(
-                "Sequence contains non-IUPAC characters, invalid FASTA format."
-            )
-    except Exception as e:
-        raise ValidationError(f"Error reading file: {str(e)}")
+        if not saw_sequence:
+            raise ValidationError("FASTA file does not contain sequence data.")
+    except ValidationError:
+        raise
+    except (OSError, UnicodeDecodeError) as e:
+        raise ValidationError(f"Error reading FASTA file: {str(e)}")
+    finally:
+        _reset_file(fieldfile)
 
 
 def user_directory_path(instance, filename):
@@ -58,7 +109,7 @@ class Fasta(models.Model):
     file = models.FileField(
         upload_to=user_directory_path,
         validators=[
-            FileExtensionValidator(["fa", "fasta", "fsa", "fna", "gz"]),
+            validate_fasta_extension,
             validate_fasta_content,
         ],
     )

--- a/mgw_api/tests/test_fasta_validation.py
+++ b/mgw_api/tests/test_fasta_validation.py
@@ -1,0 +1,36 @@
+import gzip
+
+from django.core.exceptions import ValidationError
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import SimpleTestCase
+from django.test import override_settings
+
+from mgw_api.models import validate_fasta_content
+from mgw_api.models import validate_fasta_extension
+
+
+class FastaUploadValidationTests(SimpleTestCase):
+    def test_rejects_arbitrary_gzip_extension(self):
+        upload = SimpleUploadedFile("sample.gz", gzip.compress(b">seq\nACGT\n"))
+
+        with self.assertRaises(ValidationError):
+            validate_fasta_extension(upload)
+
+    def test_accepts_fasta_gzip_extension(self):
+        upload = SimpleUploadedFile("sample.fasta.gz", gzip.compress(b">seq\nACGT\n"))
+
+        validate_fasta_extension(upload)
+        validate_fasta_content(upload)
+
+    def test_rejects_invalid_sequence_line_after_first_record(self):
+        upload = SimpleUploadedFile("sample.fa", b">seq1\nACGT\n>seq2\nACGTX\n")
+
+        with self.assertRaises(ValidationError):
+            validate_fasta_content(upload)
+
+    @override_settings(MAX_FASTA_UPLOAD_SIZE=10)
+    def test_rejects_excessive_decompressed_gzip_content(self):
+        upload = SimpleUploadedFile("sample.fa.gz", gzip.compress(b">seq\nACGTACGT\n"))
+
+        with self.assertRaises(ValidationError):
+            validate_fasta_content(upload)

--- a/vars.env.example
+++ b/vars.env.example
@@ -29,3 +29,8 @@ LDAP_ATTR_EMAIL=mail
 # Delete signatures after a successful full index batch instead of moving them
 # into metagenomes/signatures.
 DELETE_INDEXED_SIGS=False
+
+# Upload/request limits, in bytes.
+DATA_UPLOAD_MAX_MEMORY_SIZE=10485760
+FILE_UPLOAD_MAX_MEMORY_SIZE=10485760
+MAX_FASTA_UPLOAD_SIZE=52428800


### PR DESCRIPTION
## Summary
- Add configurable Django request/upload memory limits and a maximum FASTA upload size.
- Restrict gzip uploads to FASTA gzip suffixes instead of accepting arbitrary `.gz` files.
- Stream FASTA/gzip validation, validate all sequence lines, and add upload validation tests.

## Why
The previous upload path had no application-level size limit, accepted broad gzip uploads, and only checked the first sequence line. This reduces denial-of-service risk and rejects malformed uploads earlier.

Closes #227

## Verification
- `git diff --check main..HEAD`
- `python -m compileall mgw mgw_api`
- `./scripts/run-tests.sh` passed: 37 tests