### PR TITLE
Fix user media cleanup on deletion

### DIFF
--- a/mgw_api/apps.py
+++ b/mgw_api/apps.py
@@ -6,4 +6,4 @@ class MgwApiConfig(AppConfig):
     name = "mgw_api"
 
     def ready(self):
-        return
+        import mgw_api.signals  # noqa: F401

--- a/mgw_api/signals.py
+++ b/mgw_api/signals.py
@@ -1,8 +1,6 @@
-# mgw_api/signals.py
-
-import os
 import shutil
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
@@ -13,6 +11,6 @@ from mgw.settings import LOGGER
 @receiver(post_delete, sender=User)
 def delete_user_directory(sender, instance, **kwargs):
     LOGGER.info(f"Deleting user directory {instance.id}")
-    user_directory = f"user_{instance.id}"
-    if os.path.exists(user_directory):
+    user_directory = settings.MEDIA_ROOT / f"user_{instance.id}"
+    if user_directory.exists():
         shutil.rmtree(user_directory)

--- a/mgw_api/tests/test_user_cleanup.py
+++ b/mgw_api/tests/test_user_cleanup.py
@@ -1,0 +1,28 @@
+import shutil
+import tempfile
+from pathlib import Path
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.test import override_settings
+
+TEST_MEDIA_ROOT = Path(tempfile.mkdtemp())
+
+
+@override_settings(MEDIA_ROOT=TEST_MEDIA_ROOT)
+class UserCleanupTests(TestCase):
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        shutil.rmtree(TEST_MEDIA_ROOT, ignore_errors=True)
+
+    def test_user_delete_removes_media_directory(self):
+        user = User.objects.create_user(username="owner", password="testpass123")
+        user_directory = TEST_MEDIA_ROOT / f"user_{user.id}"
+        nested_file = user_directory / "search" / "result.csv"
+        nested_file.parent.mkdir(parents=True)
+        nested_file.write_text("a,b\n1,2\n")
+
+        user.delete()
+
+        self.assertFalse(user_directory.exists())


### PR DESCRIPTION
## Summary
- Import `mgw_api.signals` from `MgwApiConfig.ready()` so the user deletion receiver is registered.
- Delete user media directories using `settings.MEDIA_ROOT / f"user_{user.id}"` instead of a relative path.
- Add a regression test proving user deletion removes the media directory.

## Why
The cleanup signal existed but was not registered, and its path was relative. User deletion could leave uploaded/search data behind on disk.

Closes #228

## Verification
- `git diff --check main..HEAD`
- `python -m compileall mgw mgw_api`
- `./scripts/run-tests.sh` passed: 34 tests