### PR TITLE
Add production security settings

### DIFF
--- a/mgw/settings.py
+++ b/mgw/settings.py
@@ -65,6 +65,15 @@ env = environ.Env(
     CELERY_TASK_RESULT_TIMEOUT=(int, 60 * 60 * 6),
     CELERY_LOCK_TIMEOUT=(int, 60 * 60 * 6),
     CELERY_LOCK_BLOCKING_TIMEOUT=(int, 60),
+    SECURE_SSL_REDIRECT=(bool, False),
+    SECURE_PROXY_SSL_HEADER_ENABLED=(bool, False),
+    SESSION_COOKIE_SECURE=(bool, False),
+    CSRF_COOKIE_SECURE=(bool, False),
+    SECURE_HSTS_SECONDS=(int, 0),
+    SECURE_HSTS_INCLUDE_SUBDOMAINS=(bool, False),
+    SECURE_HSTS_PRELOAD=(bool, False),
+    SECURE_CONTENT_TYPE_NOSNIFF=(bool, True),
+    SECURE_REFERRER_POLICY=(str, "same-origin"),
 )
 
 environ.Env.read_env(BASE_DIR / "vars.env")
@@ -108,6 +117,24 @@ ALLOWED_HOSTS = [] if env("ALLOWED_HOSTS") == "" else env("ALLOWED_HOSTS").split
 CSRF_TRUSTED_ORIGINS = (
     [] if env("CSRF_TRUSTED_ORIGINS") == "" else env("CSRF_TRUSTED_ORIGINS").split(",")
 )
+
+SECURE_SSL_REDIRECT = env.bool("SECURE_SSL_REDIRECT", default=False)
+SECURE_PROXY_SSL_HEADER = (
+    ("HTTP_X_FORWARDED_PROTO", "https")
+    if env.bool("SECURE_PROXY_SSL_HEADER_ENABLED", default=not DEBUG)
+    else None
+)
+SESSION_COOKIE_SECURE = env.bool("SESSION_COOKIE_SECURE", default=not DEBUG)
+CSRF_COOKIE_SECURE = env.bool("CSRF_COOKIE_SECURE", default=not DEBUG)
+SECURE_HSTS_SECONDS = env.int(
+    "SECURE_HSTS_SECONDS", default=31536000 if not DEBUG else 0
+)
+SECURE_HSTS_INCLUDE_SUBDOMAINS = env.bool(
+    "SECURE_HSTS_INCLUDE_SUBDOMAINS", default=not DEBUG
+)
+SECURE_HSTS_PRELOAD = env.bool("SECURE_HSTS_PRELOAD", default=False)
+SECURE_CONTENT_TYPE_NOSNIFF = env.bool("SECURE_CONTENT_TYPE_NOSNIFF", default=True)
+SECURE_REFERRER_POLICY = env("SECURE_REFERRER_POLICY", default="same-origin")
 
 STATIC_ROOT = BASE_DIR / "static"
 

--- a/vars.env.example
+++ b/vars.env.example
@@ -26,6 +26,21 @@ LDAP_ATTR_EMAIL=mail
 # limit the number of results in the downloaded result files.
 #MAX_SEARCH_RESULTS=100
 
+# Production security settings. Most browser/proxy protections default to
+# enabled when DEBUG=False. Enable SECURE_SSL_REDIRECT only when Django should
+# perform redirects itself rather than relying on the front proxy.
+# Set SECURE_PROXY_SSL_HEADER_ENABLED=True when Django is behind a TLS-terminating
+# proxy that sends X-Forwarded-Proto: https.
+#SECURE_SSL_REDIRECT=True
+#SECURE_PROXY_SSL_HEADER_ENABLED=True
+#SESSION_COOKIE_SECURE=True
+#CSRF_COOKIE_SECURE=True
+#SECURE_HSTS_SECONDS=31536000
+#SECURE_HSTS_INCLUDE_SUBDOMAINS=True
+#SECURE_HSTS_PRELOAD=False
+#SECURE_CONTENT_TYPE_NOSNIFF=True
+#SECURE_REFERRER_POLICY=same-origin
+
 # Delete signatures after a successful full index batch instead of moving them
 # into metagenomes/signatures.
 DELETE_INDEXED_SIGS=False


### PR DESCRIPTION
## Summary
- Add environment-backed Django production security settings for proxy SSL handling, secure cookies, HSTS, content-type nosniff, referrer policy, and optional SSL redirects.
- Document the new settings in `vars.env.example`.
- Keep `SECURE_SSL_REDIRECT` opt-in so local/container HTTP tests and proxy-managed redirects keep working unless explicitly enabled.

## Why
The project had security middleware enabled but lacked explicit production knobs for HTTPS/proxy/cookie/browser header hardening. These settings make production behavior configurable without breaking development and test HTTP flows.

Closes #229

## Verification
- `git diff --check main..HEAD`
- `python -m compileall mgw mgw_api`
- `./scripts/run-tests.sh` passed: 33 tests