### PR TITLE
Restrict image publishing workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - "**"
+      - main
   release:
     types:
       - published
@@ -54,7 +54,8 @@ jobs:
           ./scripts/run-tests.sh --skip-build
   build-and-push:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    if: >-
+      github.event_name == 'release' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     needs:
       - pre-commit
       - django-tests


### PR DESCRIPTION
## Summary
- Stop the build-image workflow from running on every branch push.
- Keep PR validation through `pull_request` events.
- Limit image publishing to pushes to `main`, release events, and explicit manual workflow dispatch.

## Verification
- `conda run -n dev pre-commit run --files .github/workflows/build-image.yml`
- `./scripts/run-tests.sh` — 33 Django tests passed locally

## Notes
- This is intentionally based on current `main` and is separate from the split PR stack.