### PR TITLE
Restore empty manifest guard

### DIFF
--- a/mgw_api/services/maintenance.py
+++ b/mgw_api/services/maintenance.py
@@ -175,6 +175,11 @@ def prepare_download_targets(ids=None):
     )
     man_fail = settings.DATA_DIR / database / "metagenomes" / "download_failed.pickle"
     manifest = settings.DATA_DIR / database / "metagenomes" / "manifest.pickle"
+    if not ids and not manifest.exists() and not settings.INDEX_FROM_SCRATCH:
+        raise RuntimeError(
+            "manifest.pickle is missing and INDEX_FROM_SCRATCH is disabled; "
+            "create manifests first or provide explicit IDs"
+        )
     mani_list = set(get_manifest(manifest))
     if ids:
         wanted_ids = set(ids) - mani_list

--- a/mgw_api/tests/test_download_maintenance.py
+++ b/mgw_api/tests/test_download_maintenance.py
@@ -9,11 +9,25 @@ from django.test.utils import override_settings
 
 from mgw_api.services.maintenance import download_from_wort
 from mgw_api.services.maintenance import get_update_accessions
+from mgw_api.services.maintenance import prepare_download_targets
 from mgw_api.services.maintenance import run_download_index
 from mgw_api.services.maintenance import run_index
 
 
 class DownloadMaintenanceTests(SimpleTestCase):
+    @override_settings(
+        DATA_DIR=Path("/tmp/mgwatch-test-data"),
+        INDEX_FROM_SCRATCH=False,
+    )
+    def test_prepare_download_targets_requires_manifest_without_explicit_ids(self):
+        with TemporaryDirectory() as tmp_dir:
+            with override_settings(DATA_DIR=Path(tmp_dir)):
+                with self.assertRaisesMessage(
+                    RuntimeError,
+                    "manifest.pickle is missing and INDEX_FROM_SCRATCH is disabled",
+                ):
+                    prepare_download_targets()
+
     def test_get_update_accessions_reads_pending_signatures_from_updates_dir(self):
         with TemporaryDirectory() as tmp_dir:
             updates_dir = Path(tmp_dir)


### PR DESCRIPTION
## Summary
- Restore the guard that refuses implicit full downloads when `manifest.pickle` is missing and `INDEX_FROM_SCRATCH` is disabled.
- Add a regression test for `prepare_download_targets()` without explicit IDs.

## Why
Without this guard, `create_downloads` can treat a missing aggregate manifest as empty and queue all matching Mongo accessions even though the deployment is configured not to start indexing from scratch.

Fixes #255

## Verification
- `./scripts/run-tests.sh mgw_api.tests.test_download_maintenance`