### PR TITLE
Make retained signature finalization resumable

### DIFF
--- a/mgw_api/tests/test_wort_index_builder.py
+++ b/mgw_api/tests/test_wort_index_builder.py
@@ -294,3 +294,23 @@ class WortIndexBuilderTests(TestCase):
         self.assertEqual(built_ksizes, [31, 51])
         self.assertEqual(manifest, ["SRR1", "SRR2"])
         self.assertIsNone(state_data["active_batch"])
+
+    def test_finalize_retained_signatures_allows_already_moved_files(self):
+        with TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            output_paths = wort_index_builder.create_output_paths(tmp_path / "output")
+            moved_source = output_paths.updates / "SRR1.sig"
+            missing_source = output_paths.updates / "SRR2.sig"
+            (output_paths.signatures / "SRR1.sig").write_text("sig", encoding="ascii")
+            (output_paths.updates / "SRR2.sig").write_text("sig", encoding="ascii")
+
+            wort_index_builder.finalize_batch_files(
+                sig_paths=[moved_source, missing_source],
+                output_paths=output_paths,
+                retain_indexed_signatures=True,
+            )
+
+            self.assertFalse(moved_source.exists())
+            self.assertFalse(missing_source.exists())
+            self.assertTrue((output_paths.signatures / "SRR1.sig").exists())
+            self.assertTrue((output_paths.signatures / "SRR2.sig").exists())

--- a/scripts/wort-standalone-index-builder.py
+++ b/scripts/wort-standalone-index-builder.py
@@ -440,6 +440,10 @@ def finalize_batch_files(
     if retain_indexed_signatures:
         for sig_path in sig_paths:
             destination = output_paths.signatures / sig_path.name
+            if not sig_path.exists():
+                if destination.exists():
+                    continue
+                raise FileNotFoundError(f"cannot finalize missing signature {sig_path}")
             if destination.exists():
                 destination.unlink()
             shutil.move(str(sig_path), str(destination))


### PR DESCRIPTION
## Summary
- Make retained-signature finalization idempotent when a resumed builder run finds a signature already moved into `signatures/`.
- Keep raising when both the source update signature and retained destination are missing.
- Add a regression test for the partial-finalization resume state.

## Why
A standalone Wort builder run using `--retain-indexed-signatures` could fail to resume after interruption if the state had reached `manifested` and at least one signature had already been moved from `updates/` to `signatures/`. The resumed finalization tried to move the missing source path again and raised `FileNotFoundError`.

Fixes #262

## Verification
- `./scripts/run-tests.sh mgw_api.tests.test_wort_index_builder`