### PR TITLE
Load HTMX on result pages

### DIFF
--- a/mgw_api/templates/mgw_api/base_result.html
+++ b/mgw_api/templates/mgw_api/base_result.html
@@ -15,6 +15,7 @@
         <script src="https://code.jquery.com/jquery-3.7.1.min.js"
                 integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
                 crossorigin="anonymous"></script>
+        <script src="https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js" defer></script>
         <link rel="stylesheet"
               href="https://cdn.datatables.net/2.2.2/css/dataTables.dataTables.css" />
         <script src="https://cdn.datatables.net/2.2.2/js/dataTables.js"></script>


### PR DESCRIPTION
## Summary
- Load the HTMX script in `base_result.html`.

## Why
The bookmarkable result/wait page renders status fragments that use `hx-get` and `hx-trigger`, but the result-page base template did not include HTMX. Without the script, polling does not run and the page can remain stuck on the initial progress state until a manual reload.

Fixes #263

## Verification
- Previously passed: `./scripts/run-tests.sh mgw_api.tests.test_jobs.JobStatusViewTests`
- Attempted to rerun before this push, but Docker access for this exact test command was blocked by the sandbox in this turn.