### PR TITLE
Redact command output from failures

### DIFF
--- a/mgw_api/services/exceptions.py
+++ b/mgw_api/services/exceptions.py
@@ -9,24 +9,27 @@ class LockTimeoutError(Exception):
 class ExternalCommandError(Exception):
     """Raised when an external command fails."""
 
-    max_output_length = 1000
-
     def __init__(self, command, returncode, stdout="", stderr=""):
         self.command = command
         self.returncode = returncode
-        self.stdout = stdout
-        self.stderr = stderr
+        self.stdout = ""
+        self.stderr = ""
+        self.stdout_length = len(stdout or "")
+        self.stderr_length = len(stderr or "")
         executable = command[0] if command else "<empty>"
-        output = self._summarize_output(stderr or stdout)
+        output = self._summarize_output(stdout, stderr)
         message = (
             f"Command failed with exit code {returncode}: executable={executable}. "
             f"{output}".strip()
         )
         super().__init__(message)
 
-    def _summarize_output(self, output):
-        if not output:
+    def _summarize_output(self, stdout, stderr):
+        output = stderr or stdout
+        if output is None or output == "":
             return "No command output captured."
-        if len(output) <= self.max_output_length:
-            return output
-        return output[: self.max_output_length] + "... [truncated]"
+        stream = "stderr" if stderr else "stdout"
+        return (
+            f"{stream} captured {len(output)} characters; "
+            "content redacted from stored error details."
+        )

--- a/mgw_api/tests/test_external_command_errors.py
+++ b/mgw_api/tests/test_external_command_errors.py
@@ -1,0 +1,30 @@
+from django.test import SimpleTestCase
+
+from mgw_api.services.exceptions import ExternalCommandError
+
+
+class ExternalCommandErrorTests(SimpleTestCase):
+    def test_command_output_is_redacted_from_exception_message(self):
+        exc = ExternalCommandError(
+            ["sourmash", "scripts", "manysearch"],
+            1,
+            stdout="sample-id-from-stdout",
+            stderr="sensitive stderr with /data/media/user_7/sample.sig",
+        )
+
+        message = str(exc)
+
+        self.assertIn("Command failed with exit code 1", message)
+        self.assertIn("executable=sourmash", message)
+        self.assertIn("stderr captured", message)
+        self.assertIn("content redacted", message)
+        self.assertNotIn("sample-id-from-stdout", message)
+        self.assertNotIn("sensitive stderr", message)
+        self.assertNotIn("/data/media/user_7/sample.sig", message)
+        self.assertEqual(exc.stdout, "")
+        self.assertEqual(exc.stderr, "")
+        self.assertEqual(exc.stdout_length, len("sample-id-from-stdout"))
+        self.assertEqual(
+            exc.stderr_length,
+            len("sensitive stderr with /data/media/user_7/sample.sig"),
+        )


### PR DESCRIPTION
## Summary
- Redact stdout/stderr content from `ExternalCommandError` messages before they can be stored on failed jobs.
- Keep non-content metadata in the error message, including exit code, executable, stream, and output length.
- Add a regression test proving sensitive command output and paths are not present in `str(exc)`.

## Why
Failed external commands can emit user paths, sample names, or sequence-derived data. `mark_job_failed()` stores `str(exc)` in job error fields, so command output content should not be included in the exception message.

Fixes #273

## Verification
- Previously passed: `./scripts/run-tests.sh mgw_api.tests.test_external_command_errors`