### PR TITLE
Preserve duplicate-name search results

### DIFF
--- a/mgw_api/tests/test_jobs.py
+++ b/mgw_api/tests/test_jobs.py
@@ -244,6 +244,46 @@ class JobStatusViewTests(TestCase):
         self.assertContains(response, 'hx-trigger="every 5s"')
         self.assertContains(response, 'value="33"', html=False)
 
+    def test_results_page_preserves_results_for_duplicate_signature_names(self):
+        first_signature = Signature.objects.create(
+            user=self.user,
+            name="example",
+            fasta=self.fasta,
+            file="user_1/example-1.sig",
+        )
+        second_signature = Signature.objects.create(
+            user=self.user,
+            name="example",
+            fasta=self.fasta,
+            file="user_1/example-2.sig",
+        )
+        Result.objects.create(
+            user=self.user,
+            name="example",
+            signature=first_signature,
+            file="user_1/example-1.csv",
+            num_results=7,
+            kmer=[21],
+            database=["SRA"],
+            containment=0.1,
+        )
+        Result.objects.create(
+            user=self.user,
+            name="example",
+            signature=second_signature,
+            file="user_1/example-2.csv",
+            num_results=9,
+            kmer=[31],
+            database=["SRA"],
+            containment=0.1,
+        )
+
+        response = self.client.get(reverse("mgw_api:list_result"))
+
+        self.assertContains(response, "Sequence name: example", count=1)
+        self.assertContains(response, "<td>7</td>", html=True)
+        self.assertContains(response, "<td>9</td>", html=True)
+
     def test_results_page_shows_active_signature_pipeline_without_completed_results(
         self,
     ):

--- a/mgw_api/views.py
+++ b/mgw_api/views.py
@@ -343,12 +343,17 @@ def list_result(request):
                 active_job=None,
             ),
         )
-        entry.signature = signature
-        entry.fasta = signature.fasta
-        entry.sorted_results = list(
+        if entry.signature is None:
+            entry.signature = signature
+        if entry.fasta is None:
+            entry.fasta = signature.fasta
+        entry.sorted_results.extend(
             signature.result_set.all().order_by("-date", "-time")
         )
-        entry.active_job = active_search_jobs.get(signature.pk)
+        entry.sorted_results.sort(
+            key=lambda result: (result.date, result.time), reverse=True
+        )
+        entry.active_job = active_search_jobs.get(signature.pk) or entry.active_job
     for job in (
         Job.objects.filter(
             user=request.user,


### PR DESCRIPTION
## Summary
- Aggregate result rows when multiple signatures share the same user-visible name.
- Preserve active job display for grouped entries.
- Add a regression test proving duplicate signature names still render all completed results.

## Why
`Signature.name` is not unique. The grouped results page reused an existing entry for duplicate names but replaced `sorted_results` with the current signature's results, hiding results from earlier signatures in the same name group.

Fixes #257

## Verification
- Previously passed: `./scripts/run-tests.sh mgw_api.tests.test_jobs.JobStatusViewTests`