### PR TITLE
Publish Wort downloads atomically

### DIFF
--- a/mgw_api/services/maintenance.py
+++ b/mgw_api/services/maintenance.py
@@ -295,6 +295,7 @@ async def download_from_wort(
 
 async def fetch_signature(session, url, target_dir, ids_fail, man_fail, lock):
     accession = url.split("/")[-1]
+    tmp_name = None
     try:
         async with session.get(url, ssl=ssl.SSLContext()) as response:
             status = response.status
@@ -304,15 +305,23 @@ async def fetch_signature(session, url, target_dir, ids_fail, man_fail, lock):
                     await asyncio.to_thread(save_pickle, ids_fail, man_fail)
                 return {"id": accession, "status": status, "error": "non-success"}
             async with aiofiles.tempfile.NamedTemporaryFile(
-                "wb", delete=False
+                "wb",
+                delete=False,
+                dir=target_dir,
+                prefix=f".{accession}.",
+                suffix=".tmp",
             ) as handle:
+                tmp_name = handle.name
                 async for chunk in response.content.iter_chunked(1024 * 1024):
                     await handle.write(chunk)
                 await handle.flush()
-                dest = f"{target_dir}/{accession}.sig"
-                await asyncio.to_thread(shutil.move, handle.name, dest)
-            return {"id": accession, "status": status, "path": dest}
+                dest = target_dir / f"{accession}.sig"
+                await asyncio.to_thread(os.replace, handle.name, dest)
+                tmp_name = None
+            return {"id": accession, "status": status, "path": str(dest)}
     except Exception:
+        if tmp_name:
+            await asyncio.to_thread(Path(tmp_name).unlink, missing_ok=True)
         LOGGER.exception("Download exception for %s", url)
         async with lock:
             ids_fail.add(accession)

--- a/mgw_api/tests/test_download_maintenance.py
+++ b/mgw_api/tests/test_download_maintenance.py
@@ -8,9 +8,31 @@ from django.test import SimpleTestCase
 from django.test.utils import override_settings
 
 from mgw_api.services.maintenance import download_from_wort
+from mgw_api.services.maintenance import fetch_signature
 from mgw_api.services.maintenance import get_update_accessions
 from mgw_api.services.maintenance import run_download_index
 from mgw_api.services.maintenance import run_index
+
+
+class FakeDownloadContent:
+    async def iter_chunked(self, _chunk_size):
+        yield b"signature"
+
+
+class FakeDownloadResponse:
+    status = 200
+    content = FakeDownloadContent()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+class FakeDownloadSession:
+    def get(self, url, ssl=None):
+        return FakeDownloadResponse()
 
 
 class DownloadMaintenanceTests(SimpleTestCase):
@@ -56,6 +78,26 @@ class DownloadMaintenanceTests(SimpleTestCase):
             fetch_mock.call_args.args[1],
             "https://wort.sourmash.bio/v1/view/sra/SRR2",
         )
+
+    def test_fetch_signature_publishes_only_final_signature_path(self):
+        with TemporaryDirectory() as tmp_dir:
+            target_dir = Path(tmp_dir)
+            failed_pickle = target_dir / "download_failed.pickle"
+
+            result = asyncio.run(
+                fetch_signature(
+                    FakeDownloadSession(),
+                    "https://wort.sourmash.bio/v1/view/sra/SRR1",
+                    target_dir,
+                    set(),
+                    failed_pickle,
+                    asyncio.Lock(),
+                )
+            )
+
+            self.assertEqual(result["path"], str(target_dir / "SRR1.sig"))
+            self.assertEqual((target_dir / "SRR1.sig").read_bytes(), b"signature")
+            self.assertEqual(list(target_dir.glob("*.tmp")), [])
 
     @override_settings(
         DATA_DIR=Path("/tmp/mgwatch-test-data"),


### PR DESCRIPTION
## Summary
- Download Wort signatures into temporary files inside the target updates directory.
- Publish completed downloads with `os.replace()` so the final `.sig` path appears atomically.
- Remove temporary files on download exceptions.
- Add a regression test for final-path publication.

## Why
Using `shutil.move()` from the system temp directory can degrade into a copy when `/tmp` and `updates/` are on different filesystems. If that copy is interrupted, a partial final `.sig` can remain and later be treated as a completed download.

Fixes #258

## Verification
- Previously passed: `./scripts/run-tests.sh mgw_api.tests.test_download_maintenance`