### PR TITLE
Protect media in production example

### DIFF
--- a/example-config/compose.prod.yml
+++ b/example-config/compose.prod.yml
@@ -10,7 +10,7 @@ services:
       - ${EXTERNAL_DATA_DIR}/backend-data:/data
       - ${SQLITE_DIR}:/data-db
       - ${LOG_DIR}:/logs
-      - ${NGINX_DATA_DIR}/static:/static
+      - ${NGINX_DATA_DIR}/static:/code/static
     environment:
       - TZ=${TZ}
       - SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
@@ -108,7 +108,6 @@ services:
     volumes:
       - ./nginx-templates:/etc/nginx/templates:ro
       - ${NGINX_DATA_DIR}/static:/static:ro
-      - ${EXTERNAL_DATA_DIR}/backend-data/media:/media:ro
     environment:
       - TZ=${TZ}
       - NGINX_PORT=8000

--- a/example-config/nginx-templates/mgwatch.conf.template
+++ b/example-config/nginx-templates/mgwatch.conf.template
@@ -6,11 +6,6 @@ server {
     autoindex off;
   }
 
-  location /media/ {
-    alias /media/;
-    autoindex off;
-  }
-
   location / {
     proxy_pass http://mgwatch:8100;
     proxy_set_header Host $host;


### PR DESCRIPTION
## Summary
- Stop mounting backend media into the production example nginx container.
- Remove direct `/media/` serving from the production nginx template.
- Mount the shared static volume where Django `collectstatic` writes assets, while nginx continues serving that same static directory read-only.

## Why
Direct nginx serving of `/media/` bypasses Django's authenticated download views. The production example also mounted static files at `/static` in the web container while Django writes `STATIC_ROOT` to `/code/static`, so collected assets did not line up with the nginx-served static volume.

Fixes #266
Fixes #267

## Verification
- Previously passed: `./scripts/run-tests.sh mgw_api.tests.test_example_deployment_config`