### PR TITLE
Track BSI security deficiency updates

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -14,10 +14,14 @@ LOG_DIR=./work/django-logs
 # Time zone to be used inside all containers
 TZ=Europe/Berlin
 
+# Runtime UID/GID for the MetagenomeWatch application containers.
+MGWATCH_UID=1000
+MGWATCH_GID=1000
+
 # Pin docker images. We use index digests so that we get *exactly* the same
 # image every time. Labels can be changed to point to different images.
 DOCKER_NGINX_IMAGE=nginx@sha256:15d20a9e80b094bc7fea73c8207bac1d2196d02251df24c6bbc58b19af1b4fd5
-# Bumped because of mongobleed
-DOCKER_MONGODB_IMAGE=mongo:8.2.3-noble
+# Digest for mongo:8.2.3-noble.
+DOCKER_MONGODB_IMAGE=mongo@sha256:e30bf5231ff01512e7db91feda37b7ef4fd499867b89a1e13bd6988a55745cf4
 
 MAX_DOWNLOADS=1000

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,39 @@ updates:
         applies-to: version-updates
         patterns:
           - "*"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-versions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+  - package-ecosystem: "docker-compose"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-versions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+  - package-ecosystem: "docker-compose"
+    directory: "/example-config"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-versions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+  - package-ecosystem: "conda"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-versions:
+        applies-to: version-updates
+        patterns:
+          - "*"

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -1,0 +1,93 @@
+name: vulnerability-scan
+on:
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/vulnerability-scan.yml"
+      - "Dockerfile"
+      - "environment.yml"
+      - "compose*.yml"
+      - "example-config/**"
+permissions:
+  contents: read
+  security-events: write
+env:
+  IMAGE_TAG: localbuild/mgwatch:${{ github.sha }}
+  TRIVY_SEVERITY: HIGH,CRITICAL
+jobs:
+  trivy:
+    name: Trivy vulnerability scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v7
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.2.0
+      - name: Build image for scanning
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          load: true
+          tags: ${{ env.IMAGE_TAG }}
+          cache-from: type=gha,scope=vulnerability-scan
+          cache-to: type=gha,mode=max,scope=vulnerability-scan
+      - name: Generate image vulnerability SARIF
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ env.IMAGE_TAG }}
+          format: sarif
+          output: trivy-image.sarif
+          exit-code: "0"
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: ${{ env.TRIVY_SEVERITY }}
+      - name: Upload image vulnerability SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        with:
+          sarif_file: trivy-image.sarif
+          category: trivy-image
+      - name: Generate repository vulnerability SARIF
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-repository.sarif
+          exit-code: "0"
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: ${{ env.TRIVY_SEVERITY }}
+          skip-setup-trivy: true
+      - name: Upload repository vulnerability SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        with:
+          sarif_file: trivy-repository.sarif
+          category: trivy-repository
+      - name: Fail on high or critical image vulnerabilities
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ env.IMAGE_TAG }}
+          format: table
+          exit-code: "1"
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: ${{ env.TRIVY_SEVERITY }}
+          skip-setup-trivy: true
+      - name: Fail on high or critical repository vulnerabilities
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: table
+          exit-code: "1"
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: ${{ env.TRIVY_SEVERITY }}
+          skip-setup-trivy: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,4 @@
 - Use concise, present-tense commit subjects (recent history uses short sentences like “Make wort signature downloads asynchronous”). Group related changes per commit; avoid noisy rebuild artifacts or local data.
 - Pull requests should describe the change, why it’s needed, and how to verify (commands and expected outcomes). Link issues or tickets when relevant.
 - Include screenshots or sample payloads for UI/API changes, note schema or migration impacts, and call out any operational steps (e.g., rerunning `create_metadata` or `create_search` commands).
+- Do not use the `gh` CLI for GitHub operations in this sandbox. Its auth configuration is expected to fail; use the configured GitHub connector for issues, pull requests, comments, and repository metadata instead.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,19 @@
 # syntax=docker/dockerfile:1
 FROM condaforge/miniforge3:25.11.0-0
 ARG DEBIAN_FRONTEND=noninteractive
+ARG MGWATCH_UID=1000
+ARG MGWATCH_GID=1000
 
 RUN apt update --allow-releaseinfo-change && apt install -y procps wget gzip pigz bc cron && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN if ! getent group "${MGWATCH_GID}" >/dev/null; then \
+        groupadd --gid "${MGWATCH_GID}" mgwatch; \
+    fi && \
+    if ! getent passwd "${MGWATCH_UID}" >/dev/null; then \
+        useradd --uid "${MGWATCH_UID}" --gid "${MGWATCH_GID}" --create-home --home-dir /home/mgwatch --shell /usr/sbin/nologin mgwatch; \
+    else \
+        mkdir -p /home/mgwatch; \
+        chown "${MGWATCH_UID}:${MGWATCH_GID}" /home/mgwatch; \
+    fi
 
 WORKDIR /code
 COPY environment.yml .
@@ -11,4 +22,11 @@ COPY manage.py README.md .
 COPY templates/ /code/templates
 COPY mgw/ /code/mgw
 COPY mgw_api/ /code/mgw_api
-RUN SECRET_KEY=dummy conda run --no-capture-output -n mgw ./manage.py collectstatic --no-input
+RUN DEBUG=True SECRET_KEY=dummy conda run --no-capture-output -n mgw ./manage.py collectstatic --no-input
+RUN mkdir -p /code/static /data /data-db /logs /var/spool/cron/crontabs && \
+    chown -R "${MGWATCH_UID}:${MGWATCH_GID}" /code /data /data-db /logs /var/spool/cron/crontabs
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    XDG_CACHE_HOME=/tmp/.cache \
+    HOME=/home/mgwatch
+USER ${MGWATCH_UID}:${MGWATCH_GID}

--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ $ cp vars.env.example vars.env
 $ cp .env.template .env
 ```
 
+The application image runs as the non-root `mgwatch` user. For bind-mounted
+deployment directories, set `MGWATCH_UID` and `MGWATCH_GID` in `.env` and make
+sure the mounted data, SQLite, log, and static directories are writable by that
+UID/GID before starting the stack.
+
 ### Managing MetagenomeWatch docker containers
 
 The `./scripts` folder contains helper scripts you can use to perform most docker-related tasks for MetagenomeWatch.
@@ -141,3 +146,52 @@ Recommended operator workflow:
 2. Set `DOCKER_MGWATCH_IMAGE` to a pinned digest such as `ghcr.io/rki-mf1/mgwatch:sha-<git digest>`.
 3. Start services with `docker compose -f compose.prod.yml up -d`.
 4. Run maintenance commands with `docker compose -f compose.prod.yml run --rm mgwatch "conda run --no-capture-output -n mgw ./manage.py <command>"`.
+
+## Backups
+
+Backups must cover both databases and the filesystem state used by
+MetagenomeWatch: SQLite, MongoDB, media uploads, signatures, indexes, manifests,
+logs, `.env`, `vars.env`, Compose files, and NGINX/deployment configuration.
+
+Run the backup script from the deployment directory that contains `.env`,
+`vars.env`, and the Compose file:
+
+```console
+$ COMPOSE_FILE=compose.prod.yml ./scripts/backup.sh /srv/mgwatch/backups
+```
+
+For repository-local development, the defaults target `compose.yml` and write to
+`./backups`:
+
+```console
+$ ./scripts/backup.sh
+```
+
+Each run creates `mgwatch-<timestamp>/` with:
+
+- `sqlite/db.sqlite3`: online SQLite backup created through the SQLite backup API.
+- `mongodb.archive.gz`: `mongodump --archive --gzip` output when the MongoDB container is running.
+- `archives/backend-data.tar.gz`: uploaded media, signatures, indexes, manifests, and other `/data` state.
+- `archives/logs.tar.gz` and `archives/nginx-data.tar.gz`: operational logs and proxy/static deployment data.
+- `config/`: copied environment, Compose, and NGINX template files.
+- `MANIFEST.txt`: source paths and file sizes for the backup set.
+
+Store backup output outside the application data directories and protect it like
+production data because it can contain uploaded sequences, metadata, credentials,
+and operational logs. Before migrations, image upgrades, or data/index rebuilds,
+create a fresh backup and record its path in the release notes. Periodically test
+restores in a staging environment.
+
+To restore a backup, stop application traffic, make sure the target `.env` points
+to the intended restore paths, and run:
+
+```console
+$ COMPOSE_FILE=compose.prod.yml ./scripts/restore.sh --force /srv/mgwatch/backups/mgwatch-<timestamp>
+```
+
+The restore script overwrites the configured SQLite database, backend data,
+logs, NGINX/static data, and copied deployment config. If
+`mongodb.archive.gz` exists and `mgwatch-mongodb` is running, it imports the
+dump with `mongorestore --drop --archive --gzip`. After restore, start the stack,
+run migrations if required by the restored application version, and run the smoke
+tests from the release checklist.

--- a/compose-dev.yml
+++ b/compose-dev.yml
@@ -5,6 +5,9 @@
 # rebuild the container.
 services:
   mgwatch:
+    environment:
+      - DEBUG=True
+      - LOG_LEVEL=DEBUG
     ports: !override
       - "8100:8100"
     command: ["conda run --no-capture-output -n mgw ./manage.py runserver 0.0.0.0:8100"]
@@ -35,3 +38,15 @@ services:
   mgwatch-redis:
     ports: !override
       - "6379:6379"
+  mgwatch-celery-interactive:
+    environment:
+      - DEBUG=True
+      - LOG_LEVEL=DEBUG
+  mgwatch-celery-maintenance:
+    environment:
+      - DEBUG=True
+      - LOG_LEVEL=DEBUG
+  mgwatch-celery-beat:
+    environment:
+      - DEBUG=True
+      - LOG_LEVEL=DEBUG

--- a/compose.yml
+++ b/compose.yml
@@ -28,7 +28,7 @@ services:
     command: ["conda run --no-capture-output -n mgw gunicorn --workers 2 --threads 2 --bind 0.0.0.0:8100 mgw.wsgi:application"]
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "conda run --no-capture-output -n mgw python -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:8100/', timeout=5).close()\""]
+      test: ["CMD-SHELL", "conda run --no-capture-output -n mgw python -c \"import urllib.request; request = urllib.request.Request('http://127.0.0.1:8100/', headers={'Host': 'localhost'}); urllib.request.urlopen(request, timeout=5).close()\""]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,16 @@
+x-mgwatch-runtime: &mgwatch-runtime
+  user: "${MGWATCH_UID:-1000}:${MGWATCH_GID:-1000}"
+  security_opt:
+    - no-new-privileges:true
+  cap_drop:
+    - ALL
+x-container-runtime: &container-runtime
+  security_opt:
+    - no-new-privileges:true
 services:
   # This container handles both Django as well as serving static files using Whitenoise
   mgwatch:
+    !!merge <<: *mgwatch-runtime
     image: mgwatch:local
     container_name: mgwatch
     volumes:
@@ -17,14 +27,21 @@ services:
     entrypoint: /bin/sh -c
     command: ["conda run --no-capture-output -n mgw gunicorn --workers 2 --threads 2 --bind 0.0.0.0:8100 mgw.wsgi:application"]
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "conda run --no-capture-output -n mgw python -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:8100/', timeout=5).close()\""]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     ports:
       - "127.0.0.1:8100:8100"
     depends_on:
       mgwatch-mongodb:
-        condition: service_started
+        condition: service_healthy
       mgwatch-redis:
-        condition: service_started
+        condition: service_healthy
   mgwatch-celery-interactive:
+    !!merge <<: *mgwatch-runtime
     image: mgwatch:local
     container_name: mgwatch-celery-interactive
     volumes:
@@ -39,10 +56,17 @@ services:
     entrypoint: /bin/sh -c
     command: ["conda run --no-capture-output -n mgw celery -A mgw worker --queues interactive --concurrency 2 --hostname interactive@%h"]
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep -f '[c]elery.*worker.*interactive' >/dev/null"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     depends_on:
       mgwatch:
-        condition: service_started
+        condition: service_healthy
   mgwatch-celery-maintenance:
+    !!merge <<: *mgwatch-runtime
     image: mgwatch:local
     container_name: mgwatch-celery-maintenance
     volumes:
@@ -57,10 +81,17 @@ services:
     entrypoint: /bin/sh -c
     command: ["conda run --no-capture-output -n mgw celery -A mgw worker --queues maintenance,indexing,watches --concurrency 1 --hostname maintenance@%h"]
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep -f '[c]elery.*worker.*maintenance' >/dev/null"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     depends_on:
       mgwatch:
-        condition: service_started
+        condition: service_healthy
   mgwatch-celery-beat:
+    !!merge <<: *mgwatch-runtime
     image: mgwatch:local
     container_name: mgwatch-celery-beat
     volumes:
@@ -73,12 +104,19 @@ services:
       - TZ=$TZ
       - SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
     entrypoint: /bin/sh -c
-    command: ["conda run --no-capture-output -n mgw celery -A mgw beat --loglevel INFO"]
+    command: ["conda run --no-capture-output -n mgw celery -A mgw beat --loglevel INFO --schedule /tmp/celerybeat-schedule"]
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep -f '[c]elery.*beat' >/dev/null"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     depends_on:
       mgwatch:
-        condition: service_started
+        condition: service_healthy
   mgwatch-mongodb:
+    !!merge <<: *container-runtime
     image: $DOCKER_MONGODB_IMAGE
     container_name: mgwatch-mongodb
     environment:
@@ -90,7 +128,20 @@ services:
       - ${MONGODB_LOG_DIR}:/data/logs
     command: --logpath /data/logs/mongodb.log
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "mongosh --quiet --eval 'db.adminCommand({ ping: 1 }).ok' --username root --password \"$${MONGO_INITDB_ROOT_PASSWORD}\" --authenticationDatabase admin | grep -q 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
   mgwatch-redis:
+    !!merge <<: *container-runtime
     image: redis:7-alpine
     container_name: mgwatch-redis
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s

--- a/environment.yml
+++ b/environment.yml
@@ -33,4 +33,5 @@ dependencies:
   - conda-forge::redis-py=6.4.0
   - pip:
       - django-auth-ldap==5.0.0
+      - django-axes[ipware]==7.1.0
       - django-redis==5.4.0

--- a/example-config/.env.example
+++ b/example-config/.env.example
@@ -10,14 +10,21 @@ LOG_DIR=/srv/mgwatch/django-logs
 
 TZ=Europe/Berlin
 
+# Runtime UID/GID for the MetagenomeWatch application containers. The mounted
+# data, database, log, and static directories must be writable by this user.
+MGWATCH_UID=1000
+MGWATCH_GID=1000
+
 # Pin images by immutable digest for production.
 DOCKER_MGWATCH_IMAGE=ghcr.io/rki-mf1/mgwatch@sha256:CHANGE_ME
 DOCKER_NGINX_IMAGE=nginx@sha256:CHANGE_ME
-DOCKER_MONGODB_IMAGE=mongo@sha256:CHANGE_ME
+DOCKER_MONGODB_IMAGE=mongo@sha256:e30bf5231ff01512e7db91feda37b7ef4fd499867b89a1e13bd6988a55745cf4
 DOCKER_REDIS_IMAGE=redis@sha256:CHANGE_ME
 
 PUBLIC_BIND_ADDRESS=127.0.0.1
 PUBLIC_HTTP_PORT=8000
+NGINX_LOGIN_RATE_LIMIT=10r/m
+NGINX_LOGIN_RATE_BURST=5
 
 # This must match the password embedded in vars.env MONGO_URI.
 MGWATCH_MONGO_ROOT_PASSWORD=CHANGE_ME_LONG_RANDOM_MONGODB_PASSWORD

--- a/example-config/compose.prod.yml
+++ b/example-config/compose.prod.yml
@@ -1,5 +1,18 @@
+x-mgwatch-runtime: &mgwatch-runtime
+  user: "${MGWATCH_UID:-1000}:${MGWATCH_GID:-1000}"
+  security_opt:
+    - no-new-privileges:true
+  cap_drop:
+    - ALL
+  read_only: true
+  tmpfs:
+    - /tmp:rw,nosuid,nodev,size=512m
+x-container-runtime: &container-runtime
+  security_opt:
+    - no-new-privileges:true
 services:
   mgwatch:
+    !!merge <<: *mgwatch-runtime
     image: ${DOCKER_MGWATCH_IMAGE:?set DOCKER_MGWATCH_IMAGE in .env}
     container_name: mgwatch
     env_file:
@@ -18,12 +31,19 @@ services:
     command:
       - conda run --no-capture-output -n mgw ./manage.py collectstatic --no-input && conda run --no-capture-output -n mgw gunicorn --workers 2 --threads 2 --bind 0.0.0.0:8100 mgw.wsgi:application
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "conda run --no-capture-output -n mgw python -c \"import os, urllib.request; host=(os.environ.get('ALLOWED_HOSTS') or 'localhost').split(',')[0].strip(); req=urllib.request.Request('http://127.0.0.1:8100/', headers={'Host': host, 'X-Forwarded-Proto': 'https'}); urllib.request.urlopen(req, timeout=5).close()\""]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     depends_on:
       mgwatch-mongodb:
-        condition: service_started
+        condition: service_healthy
       mgwatch-redis:
-        condition: service_started
+        condition: service_healthy
   mgwatch-celery-interactive:
+    !!merge <<: *mgwatch-runtime
     image: ${DOCKER_MGWATCH_IMAGE:?set DOCKER_MGWATCH_IMAGE in .env}
     container_name: mgwatch-celery-interactive
     env_file:
@@ -41,10 +61,17 @@ services:
     command:
       - conda run --no-capture-output -n mgw celery -A mgw worker --queues interactive --concurrency 2 --hostname interactive@%h
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep -f '[c]elery.*worker.*interactive' >/dev/null"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     depends_on:
       mgwatch:
-        condition: service_started
+        condition: service_healthy
   mgwatch-celery-maintenance:
+    !!merge <<: *mgwatch-runtime
     image: ${DOCKER_MGWATCH_IMAGE:?set DOCKER_MGWATCH_IMAGE in .env}
     container_name: mgwatch-celery-maintenance
     env_file:
@@ -62,10 +89,17 @@ services:
     command:
       - conda run --no-capture-output -n mgw celery -A mgw worker --queues maintenance,indexing,watches --concurrency 1 --hostname maintenance@%h
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep -f '[c]elery.*worker.*maintenance' >/dev/null"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     depends_on:
       mgwatch:
-        condition: service_started
+        condition: service_healthy
   mgwatch-celery-beat:
+    !!merge <<: *mgwatch-runtime
     image: ${DOCKER_MGWATCH_IMAGE:?set DOCKER_MGWATCH_IMAGE in .env}
     container_name: mgwatch-celery-beat
     env_file:
@@ -81,12 +115,19 @@ services:
       - SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
     entrypoint: /bin/sh -c
     command:
-      - conda run --no-capture-output -n mgw celery -A mgw beat --loglevel INFO
+      - conda run --no-capture-output -n mgw celery -A mgw beat --loglevel INFO --schedule /tmp/celerybeat-schedule
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep -f '[c]elery.*beat' >/dev/null"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     depends_on:
       mgwatch:
-        condition: service_started
+        condition: service_healthy
   mgwatch-mongodb:
+    !!merge <<: *container-runtime
     image: ${DOCKER_MONGODB_IMAGE:?set DOCKER_MONGODB_IMAGE in .env}
     container_name: mgwatch-mongodb
     environment:
@@ -98,11 +139,25 @@ services:
       - ${MONGODB_LOG_DIR}:/data/logs
     command: --logpath /data/logs/mongodb.log
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "mongosh --quiet --eval 'db.adminCommand({ ping: 1 }).ok' --username root --password \"$${MONGO_INITDB_ROOT_PASSWORD}\" --authenticationDatabase admin | grep -q 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
   mgwatch-redis:
+    !!merge <<: *container-runtime
     image: ${DOCKER_REDIS_IMAGE:?set DOCKER_REDIS_IMAGE in .env}
     container_name: mgwatch-redis
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
   mgwatch-proxy:
+    !!merge <<: *container-runtime
     image: ${DOCKER_NGINX_IMAGE:?set DOCKER_NGINX_IMAGE in .env}
     container_name: mgwatch-proxy
     volumes:
@@ -111,9 +166,17 @@ services:
     environment:
       - TZ=${TZ}
       - NGINX_PORT=8000
+      - NGINX_LOGIN_RATE_LIMIT=${NGINX_LOGIN_RATE_LIMIT:-10r/m}
+      - NGINX_LOGIN_RATE_BURST=${NGINX_LOGIN_RATE_BURST:-5}
     ports:
       - ${PUBLIC_BIND_ADDRESS}:${PUBLIC_HTTP_PORT}:8000
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "nginx -t >/dev/null 2>&1 && test -s /var/run/nginx.pid"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
     depends_on:
       mgwatch:
-        condition: service_started
+        condition: service_healthy

--- a/example-config/nginx-templates/mgwatch.conf.template
+++ b/example-config/nginx-templates/mgwatch.conf.template
@@ -1,9 +1,25 @@
+limit_req_zone $binary_remote_addr zone=mgwatch_login:10m rate=${NGINX_LOGIN_RATE_LIMIT};
+
 server {
   listen ${NGINX_PORT};
 
   location /static/ {
     alias /static/;
     autoindex off;
+  }
+
+  location = /login/ {
+    limit_req zone=mgwatch_login burst=${NGINX_LOGIN_RATE_BURST} nodelay;
+    proxy_pass http://mgwatch:8100;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    client_max_body_size 100M;
+    client_body_buffer_size 10M;
+    proxy_connect_timeout 600;
+    proxy_send_timeout 600;
+    proxy_read_timeout 600;
   }
 
   location / {

--- a/example-config/vars.env.example
+++ b/example-config/vars.env.example
@@ -43,3 +43,12 @@ LDAP_BIND_PASSWORD=
 LDAP_SEARCH_ROOT=
 LDAP_ATTR_USERNAME=user
 LDAP_ATTR_EMAIL=mail
+
+# Login throttling. LDAP may also enforce account lockout, but this protects
+# the Django login endpoint and local-auth fallback before/alongside LDAP.
+AXES_ENABLED=True
+AXES_FAILURE_LIMIT=5
+AXES_COOLOFF_MINUTES=30
+AXES_RESET_ON_SUCCESS=True
+# mgwatch-proxy is the trusted reverse proxy in this Compose example.
+AXES_IPWARE_PROXY_COUNT=1

--- a/mgw/settings.py
+++ b/mgw/settings.py
@@ -13,11 +13,15 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 import logging
 import os
 from datetime import datetime
+from datetime import timedelta
 from pathlib import Path
+from urllib.parse import unquote
+from urllib.parse import urlsplit
 
 import environ
 import ldap
 from celery.schedules import crontab
+from django.core.exceptions import ImproperlyConfigured
 from django_auth_ldap.config import LDAPSearch
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -41,7 +45,7 @@ env = environ.Env(
     EMAIL_HOST_PASSWORD=(str, None),
     DEFAULT_FROM_EMAIL=(str, "test@mail.de"),
     LOG_DIR=(Path, Path("/logs")),
-    LOG_LEVEL=(str, "DEBUG"),
+    LOG_LEVEL=(str, "INFO"),
     INDEX_FROM_SCRATCH=(bool, False),
     INDEX_MAX_SIGNATURES=(int, 100000),
     DELETE_INDEXED_SIGS=(bool, False),
@@ -77,9 +81,64 @@ env = environ.Env(
     DATA_UPLOAD_MAX_MEMORY_SIZE=(int, 10 * 1024 * 1024),
     FILE_UPLOAD_MAX_MEMORY_SIZE=(int, 10 * 1024 * 1024),
     MAX_FASTA_UPLOAD_SIZE=(int, 50 * 1024 * 1024),
+    AXES_ENABLED=(bool, True),
+    AXES_FAILURE_LIMIT=(int, 5),
+    AXES_COOLOFF_MINUTES=(int, 30),
+    AXES_RESET_ON_SUCCESS=(bool, True),
+    AXES_IPWARE_PROXY_COUNT=(int, 0),
 )
 
 environ.Env.read_env(BASE_DIR / "vars.env")
+
+UNSAFE_SECRET_MARKERS = (
+    "CHANGE_ME",
+    "django-insecure-",
+)
+UNSAFE_SECRET_VALUES = {
+    "",
+    "dummy",
+    "example",
+    "example1",
+    "password",
+    "secret",
+    "test",
+    "test-secret",
+    "CHANGE_ME_LONG_RANDOM_DJANGO_SECRET_KEY",
+    "CHANGE_ME_LONG_RANDOM_MONGODB_PASSWORD",
+    "django-insecure-em&y0o^!@ha-kujz4qch11-a*qy8t3peg8@%+=(_+-bnwzr2%z",
+}
+
+
+def _is_unsafe_secret(value):
+    if value is None:
+        return True
+    normalized_value = str(value).strip().strip("\"'")
+    if normalized_value in UNSAFE_SECRET_VALUES:
+        return True
+    return any(marker in normalized_value for marker in UNSAFE_SECRET_MARKERS)
+
+
+def _mongo_password_from_uri(uri):
+    if not uri:
+        return None
+    try:
+        return unquote(urlsplit(uri).password or "")
+    except ValueError:
+        return None
+
+
+def unsafe_production_secret_reasons(secret_key, mongo_uri):
+    reasons = []
+    if _is_unsafe_secret(secret_key):
+        reasons.append("SECRET_KEY is unset or uses a known placeholder/default value")
+
+    mongo_password = _mongo_password_from_uri(mongo_uri)
+    if _is_unsafe_secret(mongo_password):
+        reasons.append(
+            "MONGO_URI is unset or uses a known placeholder/default password"
+        )
+    return reasons
+
 
 # The hostname to use for links (e.g. https://mgwatch.example.com)
 MGW_URL = env("MGW_URL")
@@ -118,6 +177,14 @@ MAX_DOWNLOADS = env("MAX_DOWNLOADS")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env("DEBUG")
+
+if not DEBUG:
+    unsafe_secret_reasons = unsafe_production_secret_reasons(SECRET_KEY, MONGO_URI)
+    if unsafe_secret_reasons:
+        raise ImproperlyConfigured(
+            "Unsafe production secrets are configured: "
+            + "; ".join(unsafe_secret_reasons)
+        )
 
 ALLOWED_HOSTS = [] if env("ALLOWED_HOSTS") == "" else env("ALLOWED_HOSTS").split(",")
 CSRF_TRUSTED_ORIGINS = (
@@ -184,6 +251,7 @@ LOGGING = {
 #    'branchwater.apps.BranchwaterConfig',
 INSTALLED_APPS = [
     "mgw_api.apps.MgwApiConfig",
+    "axes",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -346,6 +414,22 @@ if DEBUG:
         "INTERCEPT_REDIRECTS": False,
     }
 
+AXES_ENABLED = env("AXES_ENABLED")
+AXES_FAILURE_LIMIT = env("AXES_FAILURE_LIMIT")
+AXES_COOLOFF_TIME = timedelta(minutes=env("AXES_COOLOFF_MINUTES"))
+AXES_LOCKOUT_PARAMETERS = [["username", "ip_address"]]
+AXES_RESET_ON_SUCCESS = env("AXES_RESET_ON_SUCCESS")
+AXES_HTTP_RESPONSE_CODE = 429
+AXES_IPWARE_PROXY_COUNT = env("AXES_IPWARE_PROXY_COUNT") or None
+if AXES_IPWARE_PROXY_COUNT:
+    AXES_IPWARE_META_PRECEDENCE_ORDER = (
+        "HTTP_X_FORWARDED_FOR",
+        "REMOTE_ADDR",
+    )
+else:
+    AXES_IPWARE_META_PRECEDENCE_ORDER = ("REMOTE_ADDR",)
+MIDDLEWARE += ("axes.middleware.AxesMiddleware",)
+
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/login/"
 LOGIN_URL = "/login/"
@@ -366,6 +450,7 @@ else:
 ################################################################################
 # By default use Django's default user authentication
 AUTHENTICATION_BACKENDS = [
+    "axes.backends.AxesStandaloneBackend",
     "django.contrib.auth.backends.ModelBackend",
 ]
 
@@ -386,4 +471,4 @@ if env("LDAP_SERVER_URI"):
     # Populate Django's user database automatically with data from LDAP
     AUTH_LDAP_ALWAYS_UPDATE_USER = True
     # Try LDAP first, before reverting to default user authentication
-    AUTHENTICATION_BACKENDS.insert(0, "django_auth_ldap.backend.LDAPBackend")
+    AUTHENTICATION_BACKENDS.insert(1, "django_auth_ldap.backend.LDAPBackend")

--- a/mgw_api/tests/test_backup_restore_scripts.py
+++ b/mgw_api/tests/test_backup_restore_scripts.py
@@ -1,0 +1,141 @@
+import os
+import shutil
+import sqlite3
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+from django.conf import settings
+
+
+class BackupRestoreScriptTests(TestCase):
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp())
+        self.deploy_dir = self.tmpdir / "deploy"
+        self.backup_parent = self.tmpdir / "backups"
+        self.data_dir = self.deploy_dir / "data"
+        self.sqlite_dir = self.deploy_dir / "db"
+        self.nginx_dir = self.deploy_dir / "nginx"
+        self.log_dir = self.deploy_dir / "logs"
+        self.compose_file = self.deploy_dir / "compose.yml"
+        self.env_file = self.deploy_dir / ".env"
+        self.vars_file = self.deploy_dir / "vars.env"
+
+        for directory in (
+            self.data_dir / "backend-data" / "media",
+            self.sqlite_dir,
+            self.nginx_dir / "static",
+            self.log_dir,
+        ):
+            directory.mkdir(parents=True, exist_ok=True)
+
+        self.compose_file.write_text("services: {}\n", encoding="utf-8")
+        self.env_file.write_text(
+            "\n".join(
+                [
+                    f"EXTERNAL_DATA_DIR={self.data_dir}",
+                    f"SQLITE_DIR={self.sqlite_dir}",
+                    f"NGINX_DATA_DIR={self.nginx_dir}",
+                    f"LOG_DIR={self.log_dir}",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        self.vars_file.write_text(
+            "MONGO_URI=mongodb://root:example1@mgwatch-mongodb:27017/\n",
+            encoding="utf-8",
+        )
+
+        self._write_sqlite_value("original")
+        (self.data_dir / "backend-data" / "media" / "sequence.fa").write_text(
+            ">seq\nACGT\n",
+            encoding="utf-8",
+        )
+        (self.nginx_dir / "static" / "app.css").write_text(
+            "body { color: black; }\n",
+            encoding="utf-8",
+        )
+        (self.log_dir / "app.log").write_text("original log\n", encoding="utf-8")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_backup_and_restore_scripts_restore_files_and_sqlite(self):
+        env = {
+            **os.environ,
+            "COMPOSE_FILE": str(self.compose_file),
+            "MGWATCH_ENV_FILE": str(self.env_file),
+            "MGWATCH_VARS_FILE": str(self.vars_file),
+            "MGWATCH_SKIP_MONGO_BACKUP": "True",
+            "MGWATCH_SKIP_MONGO_RESTORE": "True",
+        }
+
+        backup_result = subprocess.run(
+            [str(settings.BASE_DIR / "scripts" / "backup.sh"), str(self.backup_parent)],
+            cwd=settings.BASE_DIR,
+            env=env,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        backup_dir = self._backup_dir_from_output(backup_result.stdout)
+
+        self._write_sqlite_value("mutated")
+        shutil.rmtree(self.data_dir / "backend-data")
+        shutil.rmtree(self.nginx_dir)
+        shutil.rmtree(self.log_dir)
+        self.compose_file.write_text("services:\n  broken: {}\n", encoding="utf-8")
+
+        subprocess.run(
+            [
+                str(settings.BASE_DIR / "scripts" / "restore.sh"),
+                "--force",
+                str(backup_dir),
+            ],
+            cwd=settings.BASE_DIR,
+            env=env,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+
+        self.assertEqual(self._read_sqlite_value(), "original")
+        self.assertEqual(
+            (self.data_dir / "backend-data" / "media" / "sequence.fa").read_text(
+                encoding="utf-8"
+            ),
+            ">seq\nACGT\n",
+        )
+        self.assertEqual(
+            (self.nginx_dir / "static" / "app.css").read_text(encoding="utf-8"),
+            "body { color: black; }\n",
+        )
+        self.assertEqual(
+            (self.log_dir / "app.log").read_text(encoding="utf-8"),
+            "original log\n",
+        )
+        self.assertEqual(
+            self.compose_file.read_text(encoding="utf-8"),
+            "services: {}\n",
+        )
+        self.assertTrue((backup_dir / "MANIFEST.txt").is_file())
+
+    def _write_sqlite_value(self, value):
+        with sqlite3.connect(self.sqlite_dir / "db.sqlite3") as connection:
+            connection.execute("CREATE TABLE IF NOT EXISTS backup_test (value TEXT)")
+            connection.execute("DELETE FROM backup_test")
+            connection.execute("INSERT INTO backup_test VALUES (?)", (value,))
+
+    def _read_sqlite_value(self):
+        with sqlite3.connect(self.sqlite_dir / "db.sqlite3") as connection:
+            row = connection.execute("SELECT value FROM backup_test").fetchone()
+        return row[0]
+
+    def _backup_dir_from_output(self, stdout):
+        prefix = "Backup written to "
+        for line in stdout.splitlines():
+            if line.startswith(prefix):
+                return Path(line.removeprefix(prefix))
+        self.fail(f"backup output did not include backup directory: {stdout}")

--- a/mgw_api/tests/test_backup_restore_scripts.py
+++ b/mgw_api/tests/test_backup_restore_scripts.py
@@ -138,4 +138,6 @@ class BackupRestoreScriptTests(TestCase):
         for line in stdout.splitlines():
             if line.startswith(prefix):
                 return Path(line.removeprefix(prefix))
-        self.fail(f"backup output did not include backup directory: {stdout}")
+        raise AssertionError(
+            f"backup output did not include backup directory: {stdout}"
+        )

--- a/mgw_api/tests/test_example_deployment_config.py
+++ b/mgw_api/tests/test_example_deployment_config.py
@@ -33,3 +33,45 @@ class ExampleDeploymentConfigTests(TestCase):
         self.assertNotIn("ALLOWED_HOSTS='*'", combined)
         self.assertNotIn("DEBUG=True", combined)
         self.assertNotIn("example1", combined)
+
+    def test_production_compose_includes_runtime_hardening_and_healthchecks(self):
+        compose_text = (EXAMPLE_CONFIG_DIR / "compose.prod.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn(
+            'user: "${MGWATCH_UID:-1000}:${MGWATCH_GID:-1000}"',
+            compose_text,
+        )
+        self.assertIn("no-new-privileges:true", compose_text)
+        self.assertIn("cap_drop:", compose_text)
+        self.assertIn("read_only: true", compose_text)
+        self.assertEqual(compose_text.count("healthcheck:"), 7)
+
+    def test_production_nginx_template_rate_limits_login(self):
+        nginx_text = (
+            EXAMPLE_CONFIG_DIR / "nginx-templates" / "mgwatch.conf.template"
+        ).read_text(encoding="utf-8")
+        env_text = (EXAMPLE_CONFIG_DIR / ".env.example").read_text(encoding="utf-8")
+        compose_text = (EXAMPLE_CONFIG_DIR / "compose.prod.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("limit_req_zone $binary_remote_addr", nginx_text)
+        self.assertIn("zone=mgwatch_login:10m", nginx_text)
+        self.assertIn("rate=${NGINX_LOGIN_RATE_LIMIT}", nginx_text)
+        self.assertIn("location = /login/", nginx_text)
+        self.assertIn(
+            "limit_req zone=mgwatch_login burst=${NGINX_LOGIN_RATE_BURST} nodelay;",
+            nginx_text,
+        )
+        self.assertIn("NGINX_LOGIN_RATE_LIMIT=10r/m", env_text)
+        self.assertIn("NGINX_LOGIN_RATE_BURST=5", env_text)
+        self.assertIn(
+            "NGINX_LOGIN_RATE_LIMIT=${NGINX_LOGIN_RATE_LIMIT:-10r/m}",
+            compose_text,
+        )
+        self.assertIn(
+            "NGINX_LOGIN_RATE_BURST=${NGINX_LOGIN_RATE_BURST:-5}",
+            compose_text,
+        )

--- a/mgw_api/tests/test_login_rate_limiting.py
+++ b/mgw_api/tests/test_login_rate_limiting.py
@@ -1,0 +1,46 @@
+from datetime import timedelta
+
+from axes.utils import reset
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.test import override_settings
+from django.urls import reverse
+
+
+@override_settings(
+    AXES_ENABLED=True,
+    AXES_FAILURE_LIMIT=2,
+    AXES_COOLOFF_TIME=timedelta(minutes=30),
+    AXES_LOCKOUT_PARAMETERS=[["username", "ip_address"]],
+    AXES_RESET_ON_SUCCESS=True,
+    AXES_HTTP_RESPONSE_CODE=429,
+)
+class LoginRateLimitingTests(TestCase):
+    def setUp(self):
+        reset()
+        self.user = User.objects.create_user(
+            username="limited-user", password="correct-password"
+        )
+        self.login_url = reverse("mgw_api:login")
+
+    def tearDown(self):
+        reset()
+
+    def test_failed_login_attempts_lock_out_username_ip_pair(self):
+        credentials = {
+            "username": self.user.username,
+            "password": "wrong-password",
+        }
+
+        self.client.post(self.login_url, credentials)
+        self.client.post(self.login_url, credentials)
+
+        response = self.client.post(
+            self.login_url,
+            {
+                "username": self.user.username,
+                "password": "correct-password",
+            },
+        )
+
+        self.assertEqual(response.status_code, 429)

--- a/mgw_api/tests/test_production_secret_guards.py
+++ b/mgw_api/tests/test_production_secret_guards.py
@@ -1,0 +1,21 @@
+from django.test import SimpleTestCase
+
+from mgw import settings as mgw_settings
+
+
+class ProductionSecretGuardTests(SimpleTestCase):
+    def test_flags_known_insecure_secret_values(self):
+        reasons = mgw_settings.unsafe_production_secret_reasons(
+            "django-insecure-em&y0o^!@ha-kujz4qch11-a*qy8t3peg8@%+=(_+-bnwzr2%z",
+            "mongodb://root:example1@mgwatch-mongodb:27017/",
+        )
+
+        self.assertEqual(len(reasons), 2)
+
+    def test_allows_non_placeholder_values(self):
+        reasons = mgw_settings.unsafe_production_secret_reasons(
+            "prod-secret-with-enough-random-looking-characters-0123456789",
+            "mongodb://root:prod-mongo-password-0123456789@mgwatch-mongodb:27017/",
+        )
+
+        self.assertEqual(reasons, [])

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/backup.sh [BACKUP_PARENT_DIR]
+
+Creates a timestamped MetagenomeWatch backup directory. The script reads host
+paths from .env by default. Override these inputs with:
+
+  COMPOSE_FILE=compose.prod.yml
+  MGWATCH_ENV_FILE=.env
+  MGWATCH_VARS_FILE=vars.env
+  MGWATCH_SKIP_MONGO_BACKUP=True
+
+Run it from the deployment directory that contains the compose and env files.
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+backup_parent=${1:-./backups}
+compose_file=${COMPOSE_FILE:-compose.yml}
+env_file=${MGWATCH_ENV_FILE:-.env}
+vars_file=${MGWATCH_VARS_FILE:-vars.env}
+timestamp=$(date -u +"%Y%m%dT%H%M%SZ")
+backup_dir="${backup_parent%/}/mgwatch-${timestamp}"
+
+mkdir -p "$backup_dir"/{config,sqlite,archives}
+
+if [[ -f "$env_file" ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    . "$env_file"
+    set +a
+fi
+
+: "${EXTERNAL_DATA_DIR:=./work/data}"
+: "${SQLITE_DIR:=./work/db}"
+: "${NGINX_DATA_DIR:=./work/nginx}"
+: "${LOG_DIR:=./work/django-logs}"
+
+compose_args=()
+if [[ -f "$env_file" ]]; then
+    compose_args+=(--env-file "$env_file")
+fi
+compose_args+=(-f "$compose_file")
+
+docker_compose() {
+    docker compose "${compose_args[@]}" "$@"
+}
+
+is_truthy() {
+    case "${1:-}" in
+        1 | true | TRUE | True | yes | YES | Yes)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+copy_if_exists() {
+    local source=$1
+    local destination=$2
+    if [[ -e "$source" ]]; then
+        cp -a "$source" "$destination"
+    fi
+}
+
+archive_dir_if_exists() {
+    local source=$1
+    local archive=$2
+    if [[ -d "$source" ]]; then
+        tar -C "$(dirname "$source")" -czf "$archive" "$(basename "$source")"
+    fi
+}
+
+python_bin=$(command -v python3 || command -v python)
+
+sqlite_db="${SQLITE_DIR%/}/db.sqlite3"
+if [[ -f "$sqlite_db" ]]; then
+    "$python_bin" - "$sqlite_db" "$backup_dir/sqlite/db.sqlite3" <<'PY'
+import sqlite3
+import sys
+
+source_path, backup_path = sys.argv[1:3]
+source = sqlite3.connect(source_path)
+backup = sqlite3.connect(backup_path)
+with backup:
+    source.backup(backup)
+source.close()
+backup.close()
+PY
+else
+    printf 'WARN: SQLite database not found at %s\n' "$sqlite_db" >&2
+fi
+
+copy_if_exists "$env_file" "$backup_dir/config/"
+copy_if_exists "$vars_file" "$backup_dir/config/"
+copy_if_exists "$compose_file" "$backup_dir/config/"
+copy_if_exists nginx-templates "$backup_dir/config/"
+copy_if_exists example-config/nginx-templates "$backup_dir/config/"
+
+archive_dir_if_exists "${EXTERNAL_DATA_DIR%/}/backend-data" "$backup_dir/archives/backend-data.tar.gz"
+archive_dir_if_exists "$LOG_DIR" "$backup_dir/archives/logs.tar.gz"
+archive_dir_if_exists "$NGINX_DATA_DIR" "$backup_dir/archives/nginx-data.tar.gz"
+
+mongo_password=${MGWATCH_MONGO_ROOT_PASSWORD:-}
+if [[ -z "$mongo_password" && -f "$vars_file" ]]; then
+    mongo_password=$("$python_bin" - "$vars_file" <<'PY'
+import shlex
+import sys
+from urllib.parse import unquote, urlsplit
+
+for line in open(sys.argv[1], encoding="utf-8"):
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or "=" not in stripped:
+        continue
+    key, value = stripped.split("=", 1)
+    if key.strip() == "MONGO_URI":
+        parts = shlex.split(value, comments=False)
+        if parts:
+            print(unquote(urlsplit(parts[0]).password or ""))
+        break
+PY
+)
+fi
+mongo_password=${mongo_password:-example1}
+
+if is_truthy "${MGWATCH_SKIP_MONGO_BACKUP:-}"; then
+    printf 'WARN: MGWATCH_SKIP_MONGO_BACKUP is set; skipped MongoDB dump\n' >&2
+elif docker_compose ps --status running --services | grep -qx mgwatch-mongodb; then
+    docker_compose exec -T mgwatch-mongodb mongodump \
+        --archive \
+        --gzip \
+        --username root \
+        --password "$mongo_password" \
+        --authenticationDatabase admin \
+        > "$backup_dir/mongodb.archive.gz"
+else
+    printf 'WARN: mgwatch-mongodb is not running; skipped MongoDB dump\n' >&2
+fi
+
+{
+    printf 'created_at_utc=%s\n' "$timestamp"
+    printf 'compose_file=%s\n' "$compose_file"
+    printf 'env_file=%s\n' "$env_file"
+    printf 'vars_file=%s\n' "$vars_file"
+    printf 'sqlite_source=%s\n' "$sqlite_db"
+    printf 'backend_data_source=%s\n' "${EXTERNAL_DATA_DIR%/}/backend-data"
+    printf 'log_source=%s\n' "$LOG_DIR"
+    printf 'nginx_data_source=%s\n' "$NGINX_DATA_DIR"
+    printf '\nfiles:\n'
+    find "$backup_dir" -type f -printf '%P\t%s bytes\n' | sort
+} > "$backup_dir/MANIFEST.txt"
+
+printf 'Backup written to %s\n' "$backup_dir"

--- a/scripts/dc-dev.sh
+++ b/scripts/dc-dev.sh
@@ -1,3 +1,35 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if [[ -f .env ]]; then
+    set -a
+    # shellcheck disable=SC1091
+    . ./.env
+    set +a
+fi
+
+: "${EXTERNAL_DATA_DIR:=./work/data}"
+: "${MONGODB_DATA_DIR:=./work/mongo}"
+: "${MONGODB_LOG_DIR:=./work/mongo-logs}"
+: "${SQLITE_DIR:=./work/db}"
+: "${LOG_DIR:=./work/django-logs}"
+
+mkdir -p \
+    "${EXTERNAL_DATA_DIR%/}/backend-data" \
+    "${EXTERNAL_DATA_DIR%/}/backend-crontabs" \
+    "$MONGODB_DATA_DIR" \
+    "$MONGODB_LOG_DIR" \
+    "$SQLITE_DIR" \
+    "$LOG_DIR"
+chmod -R ugo+rwX \
+    "$EXTERNAL_DATA_DIR" \
+    "$MONGODB_DATA_DIR" \
+    "$MONGODB_LOG_DIR" \
+    "$SQLITE_DIR" \
+    "$LOG_DIR" 2>/dev/null || true
+
 docker compose -f compose.yml -f compose-dev.yml "$@"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/restore.sh --force BACKUP_DIR
+
+Restores a backup created by scripts/backup.sh. The script reads host paths from
+.env by default, falling back to the backed-up .env if the current file is
+missing. Override these inputs with:
+
+  COMPOSE_FILE=compose.prod.yml
+  MGWATCH_ENV_FILE=.env
+  MGWATCH_VARS_FILE=vars.env
+  MGWATCH_SKIP_MONGO_RESTORE=True
+
+Run it from the deployment directory that contains the compose and env files.
+The --force flag is required because restore overwrites local application state.
+EOF
+}
+
+force=0
+backup_dir=
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        --force)
+            force=1
+            shift
+            ;;
+        *)
+            if [[ -n "$backup_dir" ]]; then
+                usage >&2
+                exit 2
+            fi
+            backup_dir=$1
+            shift
+            ;;
+    esac
+done
+
+if [[ "$force" -ne 1 || -z "$backup_dir" ]]; then
+    usage >&2
+    exit 2
+fi
+
+if [[ ! -d "$backup_dir" ]]; then
+    printf 'ERROR: backup directory not found: %s\n' "$backup_dir" >&2
+    exit 1
+fi
+
+compose_file=${COMPOSE_FILE:-compose.yml}
+env_file=${MGWATCH_ENV_FILE:-.env}
+vars_file=${MGWATCH_VARS_FILE:-vars.env}
+
+backup_config_file() {
+    local target=$1
+    local basename_target
+    basename_target=$(basename "$target")
+    if [[ -f "$backup_dir/config/$basename_target" ]]; then
+        printf '%s\n' "$backup_dir/config/$basename_target"
+    fi
+}
+
+source_env_file=$env_file
+if [[ ! -f "$source_env_file" ]]; then
+    source_env_file=$(backup_config_file "$env_file" || true)
+fi
+
+if [[ -n "${source_env_file:-}" && -f "$source_env_file" ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    . "$source_env_file"
+    set +a
+fi
+
+: "${EXTERNAL_DATA_DIR:=./work/data}"
+: "${SQLITE_DIR:=./work/db}"
+: "${NGINX_DATA_DIR:=./work/nginx}"
+: "${LOG_DIR:=./work/django-logs}"
+
+compose_args=()
+if [[ -f "$env_file" ]]; then
+    compose_args+=(--env-file "$env_file")
+elif [[ -n "$(backup_config_file "$env_file" || true)" ]]; then
+    compose_args+=(--env-file "$(backup_config_file "$env_file")")
+fi
+compose_args+=(-f "$compose_file")
+
+docker_compose() {
+    docker compose "${compose_args[@]}" "$@"
+}
+
+is_truthy() {
+    case "${1:-}" in
+        1 | true | TRUE | True | yes | YES | Yes)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+restore_config_file() {
+    local target=$1
+    local source
+    source=$(backup_config_file "$target" || true)
+    if [[ -n "$source" ]]; then
+        mkdir -p "$(dirname "$target")"
+        cp -a "$source" "$target"
+    fi
+}
+
+restore_archive() {
+    local archive=$1
+    local target=$2
+    local extract_dir extracted_top
+
+    if [[ ! -f "$archive" ]]; then
+        return 0
+    fi
+
+    extract_dir=$(mktemp -d "${TMPDIR:-/tmp}/mgwatch-restore.XXXXXX")
+    tar -C "$extract_dir" -xzf "$archive"
+    extracted_top=$(find "$extract_dir" -mindepth 1 -maxdepth 1 -type d -print -quit)
+    if [[ -z "$extracted_top" ]]; then
+        rm -rf "$extract_dir"
+        printf 'ERROR: archive did not contain a top-level directory: %s\n' "$archive" >&2
+        exit 1
+    fi
+
+    mkdir -p "$(dirname "$target")"
+    rm -rf "$target"
+    mv "$extracted_top" "$target"
+    rm -rf "$extract_dir"
+}
+
+restore_sqlite() {
+    local source_db="$backup_dir/sqlite/db.sqlite3"
+    local target_db="${SQLITE_DIR%/}/db.sqlite3"
+    if [[ ! -f "$source_db" ]]; then
+        printf 'WARN: SQLite backup not found at %s; skipped SQLite restore\n' "$source_db" >&2
+        return 0
+    fi
+
+    mkdir -p "$(dirname "$target_db")"
+    cp -a "$source_db" "$target_db.tmp"
+    mv "$target_db.tmp" "$target_db"
+}
+
+restore_sqlite
+restore_archive "$backup_dir/archives/backend-data.tar.gz" "${EXTERNAL_DATA_DIR%/}/backend-data"
+restore_archive "$backup_dir/archives/logs.tar.gz" "$LOG_DIR"
+restore_archive "$backup_dir/archives/nginx-data.tar.gz" "$NGINX_DATA_DIR"
+restore_config_file "$env_file"
+restore_config_file "$vars_file"
+restore_config_file "$compose_file"
+
+if [[ -d "$backup_dir/config/nginx-templates" ]]; then
+    nginx_template_dir=${NGINX_TEMPLATE_DIR:-nginx-templates}
+    rm -rf "$nginx_template_dir"
+    cp -a "$backup_dir/config/nginx-templates" "$nginx_template_dir"
+fi
+
+mongo_password=${MGWATCH_MONGO_ROOT_PASSWORD:-}
+if [[ -z "$mongo_password" && -f "$vars_file" ]]; then
+    python_bin=$(command -v python3 || command -v python)
+    mongo_password=$("$python_bin" - "$vars_file" <<'PY'
+import shlex
+import sys
+from urllib.parse import unquote, urlsplit
+
+for line in open(sys.argv[1], encoding="utf-8"):
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or "=" not in stripped:
+        continue
+    key, value = stripped.split("=", 1)
+    if key.strip() == "MONGO_URI":
+        parts = shlex.split(value, comments=False)
+        if parts:
+            print(unquote(urlsplit(parts[0]).password or ""))
+        break
+PY
+)
+fi
+mongo_password=${mongo_password:-example1}
+
+if [[ ! -f "$backup_dir/mongodb.archive.gz" ]]; then
+    printf 'WARN: MongoDB backup archive not found; skipped MongoDB restore\n' >&2
+elif is_truthy "${MGWATCH_SKIP_MONGO_RESTORE:-}"; then
+    printf 'WARN: MGWATCH_SKIP_MONGO_RESTORE is set; skipped MongoDB restore\n' >&2
+elif docker_compose ps --status running --services | grep -qx mgwatch-mongodb; then
+    docker_compose exec -T mgwatch-mongodb mongorestore \
+        --drop \
+        --archive \
+        --gzip \
+        --username root \
+        --password "$mongo_password" \
+        --authenticationDatabase admin \
+        < "$backup_dir/mongodb.archive.gz"
+else
+    printf 'WARN: mgwatch-mongodb is not running; skipped MongoDB restore\n' >&2
+fi
+
+printf 'Restore completed from %s\n' "$backup_dir"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -30,16 +30,29 @@ if [[ ! -f vars.env ]]; then
     cp vars.env.example vars.env
 fi
 
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/mgwatch-tests.XXXXXX")
+test_project_suffix=$(basename "$test_root" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9_-' '-')
+export COMPOSE_PROJECT_NAME="mgwatch-tests-${test_project_suffix}"
+export EXTERNAL_DATA_DIR="$test_root/data"
+export MONGODB_DATA_DIR="$test_root/mongo"
+export MONGODB_LOG_DIR="$test_root/mongo-logs"
+export SQLITE_DIR="$test_root/db"
+export NGINX_DATA_DIR="$test_root/nginx"
+export LOG_DIR="$test_root/django-logs"
+
 mkdir -p \
-    work/data/backend-data \
-    work/data/backend-crontabs \
-    work/mongo \
-    work/mongo-logs \
-    work/db \
-    work/django-logs
+    "$EXTERNAL_DATA_DIR/backend-data" \
+    "$EXTERNAL_DATA_DIR/backend-crontabs" \
+    "$MONGODB_DATA_DIR" \
+    "$MONGODB_LOG_DIR" \
+    "$SQLITE_DIR" \
+    "$NGINX_DATA_DIR" \
+    "$LOG_DIR"
+chmod -R ugo+rwX "$test_root"
 
 cleanup() {
     docker compose -f compose.yml down --remove-orphans
+    rm -rf "$test_root" 2>/dev/null || true
 }
 trap cleanup EXIT
 
@@ -56,5 +69,9 @@ if [[ -d example-config ]]; then
 fi
 
 docker compose -f compose.yml up -d mgwatch-mongodb
-docker compose -f compose.yml run --rm --entrypoint conda "${test_volumes[@]}" mgwatch \
+docker compose -f compose.yml run --rm --entrypoint conda \
+    -e DEBUG=True \
+    -e LOG_LEVEL=DEBUG \
+    -e AXES_ENABLED=False \
+    "${test_volumes[@]}" mgwatch \
     run --no-capture-output -n mgw ./manage.py test "${django_args[@]}"

--- a/scripts/test-changeset-against-main.sh
+++ b/scripts/test-changeset-against-main.sh
@@ -122,12 +122,16 @@ compose_run_no_deps() {
   local suite_dir="$RUN_ROOT/$label"
   local project="mgwatch-${label//[^a-zA-Z0-9]/-}"
   mkdir -p "$suite_dir"/{data/backend-data,db,django-logs,smoke}
+  chmod -R ugo+rwX "$suite_dir"/{data,db,django-logs}
 
   mapfile -d '' env_args < <(compose_env_args "$suite_dir" "$project")
   env "${env_args[@]}" "$repo_dir/scripts/dc-dev.sh" run --rm --no-deps \
     -e DATA_DIR=/data \
     -e DB_DIR=/data-db \
     -e LOG_DIR=/logs \
+    -e DEBUG=True \
+    -e LOG_LEVEL=DEBUG \
+    -e AXES_ENABLED=False \
     -e CELERY_TASK_ALWAYS_EAGER=True \
     -e CELERY_TASK_EAGER_PROPAGATES=True \
     -e REDIS_URL=redis://mgwatch-redis:6379/0 \

--- a/vars.env.example
+++ b/vars.env.example
@@ -49,3 +49,12 @@ DELETE_INDEXED_SIGS=False
 DATA_UPLOAD_MAX_MEMORY_SIZE=10485760
 FILE_UPLOAD_MAX_MEMORY_SIZE=10485760
 MAX_FASTA_UPLOAD_SIZE=52428800
+
+# Login throttling. LDAP may also enforce account lockout, but this protects
+# the Django login endpoint and local-auth fallback before/alongside LDAP.
+AXES_ENABLED=True
+AXES_FAILURE_LIMIT=5
+AXES_COOLOFF_MINUTES=30
+AXES_RESET_ON_SUCCESS=True
+# Set to the number of trusted reverse proxies in front of Django.
+AXES_IPWARE_PROXY_COUNT=0


### PR DESCRIPTION
## Summary
- Default production logging to INFO while keeping development/test paths configurable for DEBUG.
- Harden runtime and production example configuration with non-root execution, security options, pinned image inputs, production secret guards, health checks, and NGINX login rate limiting.
- Add backup/restore scripts and tests, Dependabot/Trivy scanning, and app-level login throttling with django-axes.

## BSI deficiency references
- Addresses #231
- Addresses #232
- Addresses #233
- Addresses #234
- Addresses #216
- Addresses #238
- Addresses #239

## Validation
- Not rerun in this push-only step; changes are already committed locally on `bsi/security-deficiencies-baseline`.

Base branch for follow-up BSI PRs: `bsi/security-deficiencies-baseline`.