### PR TITLE
Document release governance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+Release entries are generated from local git history and finalized during
+release closeout. Generate a draft with:
+
+```bash
+python scripts/generate-release-notes.py --from <previous-release-ref> --to <release-ref> --output release-notes.md
+```
+
+Copy the finalized notes into this file or attach them to the GitHub Release,
+and record the deployed image digest in the operations log.
+
+## Unreleased
+
+- Pending release notes are generated during the next release.

--- a/docs/deployment-with-images.md
+++ b/docs/deployment-with-images.md
@@ -48,3 +48,4 @@ Prefer digest pinning for reproducibility.
 ## Related documentation
 
 - [Production release checklist](./release-checklist.md)
+- [Release governance](./release-governance.md)

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -11,10 +11,17 @@ Use this checklist when promoting a MetagenomeWatch change from merge to safe pr
   ```
 
 - [ ] Review generated migration files and commit them with the application change.
-- [ ] Pull request approved and merged to `main`.
-- [ ] Changelog/release notes drafted (what changed, risk areas, rollback notes).
+- [ ] Pull request or tracked branch exists, CI passed, and the release owner reviewed the final diff.
+- [ ] Generate draft release notes:
+
+  ```bash
+  python scripts/generate-release-notes.py --from <previous-release-ref> --to <release-ref> --output release-notes.md
+  ```
+
+- [ ] Review generated release notes for what changed, security-relevant changes, risk areas, migration notes, and rollback notes.
 - [ ] Any required schema/data migration steps identified.
 - [ ] Confirm the merge commit already contains every required migration file before the image build starts.
+- [ ] Confirm release governance evidence expectations in [release-governance.md](./release-governance.md).
 
 ## 2) Build and publish the backend image
 
@@ -22,6 +29,7 @@ Use this checklist when promoting a MetagenomeWatch change from merge to safe pr
 - [ ] Image is published to GHCR.
 - [ ] Record immutable image digest (`sha256:...`) for deployment.
 - [ ] Optional: create a semantic release tag (e.g. `v1.6.0`) mapped to the same digest.
+- [ ] Record CI run links and image digest artifact location in the operations log or change request.
 
 ## 3) Promote to staging first
 
@@ -57,6 +65,7 @@ Use this checklist when promoting a MetagenomeWatch change from merge to safe pr
 - [ ] Verify `DEBUG=False`, `ALLOWED_HOSTS`, and other production settings in `vars.env`.
 - [ ] Confirm maintenance window and owner/on-call coverage.
 - [ ] Capture rollback target digest before rollout.
+- [ ] Record the last branch-protection verification date or evidence location.
 
 ## 5) Roll out to production
 
@@ -91,12 +100,14 @@ Use this checklist when promoting a MetagenomeWatch change from merge to safe pr
 ## 7) Post-release closeout
 
 - [ ] Announce rollout completion.
-- [ ] Save the deployed digest + release notes in your operations log.
+- [ ] Finalize `CHANGELOG.md` or attach finalized notes to the GitHub Release.
+- [ ] Save the deployed digest, rollback digest, release notes, CI links, and smoke-test result in your operations log.
 - [ ] Track any follow-up fixes discovered during rollout.
 
 ## Suggested policy guardrails
 
 - Keep production deployment artifacts in a dedicated ops repo/directory.
 - Pin production to image digests (not mutable tags like `latest`).
-- Require review/approval for digest updates in production configuration.
+- In the current single-maintainer model, document release-owner final diff review instead of requiring independent PR approval.
+- Require independent review/approval for production-impacting changes once a second qualified maintainer is available.
 - Do not keep dev helper scripts on production hosts.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -30,6 +30,7 @@ Use this checklist when promoting a MetagenomeWatch change from merge to safe pr
 - [ ] Record immutable image digest (`sha256:...`) for deployment.
 - [ ] Optional: create a semantic release tag (e.g. `v1.6.0`) mapped to the same digest.
 - [ ] Record CI run links and image digest artifact location in the operations log or change request.
+- [ ] Verify the latest successful `vulnerability-scan` run covers the release commit on `main`; if not, run it manually with `workflow_dispatch` and record the result.
 
 ## 3) Promote to staging first
 

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -30,10 +30,17 @@ Repository administrators should configure `main` branch protection in GitHub
 where available:
 
 - prevent force pushes and branch deletion;
-- require status checks for the test, lint, image build, and vulnerability scan
-  workflows that are relevant to the change;
+- require status checks that run on pull requests for the test, lint, and image
+  build workflows that are relevant to the change;
 - require branches to be up to date before merge when practical;
 - restrict direct pushes to `main`, except documented emergency admin actions.
+
+Do not configure scheduled or manual-only workflows as required PR status checks
+unless they also report a `pull_request` status. The `vulnerability-scan`
+workflow is intentionally release evidence rather than a PR merge gate: it runs
+on pushes to `main`, by weekly schedule, and by manual dispatch. Releases must
+use a scanned `main` commit or a manual scan result for the release commit before
+production rollout.
 
 These settings live in GitHub repository configuration rather than in this
 repository. Verify them periodically and record the verification date or
@@ -46,6 +53,7 @@ and how it was deployed:
 
 - pull request or merge commit link;
 - passing CI run links;
+- vulnerability scan evidence for the released `main` commit;
 - generated release notes or changelog entry;
 - published image digest;
 - production deployment digest;

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -1,0 +1,58 @@
+# Release Governance
+
+This document describes the release governance controls used for
+MetagenomeWatch and the evidence that can be referenced from the
+IT-Grundschutz-Check.
+
+## Current operating model
+
+The project currently has one active maintainer. Because the same person would
+normally submit and approve each pull request, mandatory independent PR review
+is not a realistic control at this team size. This is a documented residual
+governance limitation.
+
+Compensating controls are:
+
+- changes are prepared on branches and merged through pull requests when
+  practical;
+- CI checks must pass before production release;
+- release notes are generated from git history and finalized for each release;
+- production deployments use immutable image digests;
+- rollback digests are captured before rollout;
+- deployment evidence is recorded in an operations log or change request.
+
+If a second qualified maintainer becomes available, require at least one
+independent approval for production-impacting changes before merge or release.
+
+## Branch protection requirements
+
+Repository administrators should configure `main` branch protection in GitHub
+where available:
+
+- prevent force pushes and branch deletion;
+- require status checks for the test, lint, image build, and vulnerability scan
+  workflows that are relevant to the change;
+- require branches to be up to date before merge when practical;
+- restrict direct pushes to `main`, except documented emergency admin actions.
+
+These settings live in GitHub repository configuration rather than in this
+repository. Verify them periodically and record the verification date or
+screenshot location in the operations log.
+
+## Release evidence
+
+For each production release, retain enough evidence to reconstruct what changed
+and how it was deployed:
+
+- pull request or merge commit link;
+- passing CI run links;
+- generated release notes or changelog entry;
+- published image digest;
+- production deployment digest;
+- rollback target digest;
+- backup path or confirmation where applicable;
+- smoke-test result and log review outcome;
+- production change request or operations-log entry.
+
+The [production release checklist](./release-checklist.md) defines the release
+steps that collect this evidence.

--- a/mgw_api/tests/test_release_notes_generator.py
+++ b/mgw_api/tests/test_release_notes_generator.py
@@ -1,0 +1,103 @@
+import importlib.util
+import subprocess
+import tempfile
+from datetime import datetime
+from datetime import timezone
+from pathlib import Path
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "generate-release-notes.py"
+)
+
+
+def load_generator():
+    spec = importlib.util.spec_from_file_location("generate_release_notes", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ReleaseNotesGeneratorTests(SimpleTestCase):
+    def setUp(self):
+        self.generator = load_generator()
+
+    def test_parse_git_log_records(self):
+        output = "abc123\x1fabc123\x1fAdd login hardening\x1e"
+
+        commits = self.generator.parse_git_log(output)
+
+        self.assertEqual(len(commits), 1)
+        self.assertEqual(commits[0].sha, "abc123")
+        self.assertEqual(commits[0].short_sha, "abc123")
+        self.assertEqual(commits[0].subject, "Add login hardening")
+
+    def test_render_release_notes_groups_commits(self):
+        commits = [
+            self.generator.Commit("a" * 40, "aaaaaaa", "Add login throttling"),
+            self.generator.Commit("b" * 40, "bbbbbbb", "Update README"),
+            self.generator.Commit("c" * 40, "ccccccc", "Refactor helpers"),
+        ]
+
+        notes = self.generator.render_release_notes(
+            commits,
+            from_ref="v1.0.0",
+            to_ref="HEAD",
+            generated_at=datetime(2026, 7, 14, 12, 30, tzinfo=timezone.utc),
+        )
+
+        self.assertIn("Generated: 2026-07-14 12:30:00Z", notes)
+        self.assertIn("Range: `v1.0.0..HEAD`", notes)
+        self.assertIn("## Security", notes)
+        self.assertIn("- Add login throttling (`aaaaaaa`)", notes)
+        self.assertIn("## Documentation", notes)
+        self.assertIn("- Update README (`bbbbbbb`)", notes)
+        self.assertIn("## Other changes", notes)
+        self.assertIn("- Refactor helpers (`ccccccc`)", notes)
+
+    def test_collect_commits_uses_local_git_history(self):
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="abc123\x1fabc123\x1fAdd backup script\x1e",
+        )
+
+        with patch("subprocess.run", return_value=completed) as run:
+            commits = self.generator.collect_commits("v1.0.0", "HEAD")
+
+        self.assertEqual(commits[0].subject, "Add backup script")
+        run.assert_called_once()
+        args = run.call_args.args[0]
+        self.assertEqual(args[0], "git")
+        self.assertIn("v1.0.0..HEAD", args)
+
+    def test_main_writes_output_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "release-notes.md"
+            completed = subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="abc123\x1fabc123\x1fAdd CI gate\x1e",
+            )
+
+            with (
+                patch("subprocess.run", return_value=completed),
+                patch(
+                    "sys.argv",
+                    [
+                        "generate-release-notes.py",
+                        "--from",
+                        "v1.0.0",
+                        "--to",
+                        "HEAD",
+                        "--output",
+                        str(output_path),
+                    ],
+                ),
+            ):
+                self.generator.main()
+
+            self.assertTrue(output_path.exists())
+            self.assertIn("Add CI gate", output_path.read_text(encoding="utf-8"))

--- a/scripts/generate-release-notes.py
+++ b/scripts/generate-release-notes.py
@@ -1,0 +1,182 @@
+import argparse
+import subprocess
+from collections import OrderedDict
+from dataclasses import dataclass
+from datetime import datetime
+from datetime import timezone
+from pathlib import Path
+
+FIELD_SEPARATOR = "\x1f"
+RECORD_SEPARATOR = "\x1e"
+
+CATEGORIES = OrderedDict(
+    [
+        (
+            "Security",
+            (
+                "auth",
+                "cookie",
+                "credential",
+                "ldap",
+                "login",
+                "secret",
+                "security",
+                "vulnerability",
+            ),
+        ),
+        (
+            "Operations",
+            (
+                "backup",
+                "compose",
+                "deploy",
+                "digest",
+                "docker",
+                "health",
+                "monitor",
+                "restore",
+                "retention",
+            ),
+        ),
+        (
+            "Tests/CI",
+            (
+                "ci",
+                "coverage",
+                "dependabot",
+                "github actions",
+                "smoke",
+                "test",
+                "trivy",
+                "workflow",
+            ),
+        ),
+        (
+            "Documentation",
+            (
+                "changelog",
+                "docs",
+                "documentation",
+                "readme",
+                "release notes",
+            ),
+        ),
+    ]
+)
+
+
+@dataclass(frozen=True)
+class Commit:
+    sha: str
+    short_sha: str
+    subject: str
+
+
+def parse_git_log(output):
+    commits = []
+    for record in output.strip(RECORD_SEPARATOR).split(RECORD_SEPARATOR):
+        record = record.strip()
+        if not record:
+            continue
+        fields = record.split(FIELD_SEPARATOR)
+        if len(fields) != 3:
+            raise ValueError(f"Unexpected git log record: {record!r}")
+        commits.append(Commit(sha=fields[0], short_sha=fields[1], subject=fields[2]))
+    return commits
+
+
+def collect_commits(from_ref, to_ref):
+    result = subprocess.run(
+        [
+            "git",
+            "log",
+            "--reverse",
+            f"--format=%H{FIELD_SEPARATOR}%h{FIELD_SEPARATOR}%s{RECORD_SEPARATOR}",
+            f"{from_ref}..{to_ref}",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return parse_git_log(result.stdout)
+
+
+def classify_subject(subject):
+    normalized = subject.lower()
+    for category, keywords in CATEGORIES.items():
+        if any(keyword in normalized for keyword in keywords):
+            return category
+    return "Other changes"
+
+
+def group_commits(commits):
+    grouped = OrderedDict((category, []) for category in CATEGORIES)
+    grouped["Other changes"] = []
+    for commit in commits:
+        grouped[classify_subject(commit.subject)].append(commit)
+    return grouped
+
+
+def render_release_notes(commits, *, from_ref, to_ref, generated_at=None):
+    generated_at = generated_at or datetime.now(timezone.utc)
+    timestamp = generated_at.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
+    lines = [
+        "# Release Notes",
+        "",
+        f"Generated: {timestamp}",
+        f"Range: `{from_ref}..{to_ref}`",
+        "",
+    ]
+    if not commits:
+        lines.extend(["No commits found in this range.", ""])
+        return "\n".join(lines)
+
+    for category, category_commits in group_commits(commits).items():
+        if not category_commits:
+            continue
+        lines.extend([f"## {category}", ""])
+        for commit in category_commits:
+            lines.append(f"- {commit.subject} (`{commit.short_sha}`)")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Generate draft release notes from local git history."
+    )
+    parser.add_argument(
+        "--from",
+        dest="from_ref",
+        required=True,
+        help="Previous release tag or commit.",
+    )
+    parser.add_argument(
+        "--to",
+        dest="to_ref",
+        default="HEAD",
+        help="Target release tag, commit, or branch. Defaults to HEAD.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional Markdown output path. Defaults to stdout.",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    notes = render_release_notes(
+        collect_commits(args.from_ref, args.to_ref),
+        from_ref=args.from_ref,
+        to_ref=args.to_ref,
+    )
+    if args.output:
+        args.output.write_text(notes, encoding="utf-8")
+    else:
+        print(notes, end="")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add release governance documentation for the current single-maintainer operating model and compensating controls.
- Add a local-git release notes generator and `CHANGELOG.md` starter.
- Update the release checklist to require release-owner diff review, CI evidence, generated notes, digest tracking, rollback digest, and branch-protection verification evidence without requiring unrealistic same-person PR approval.

## BSI deficiency references
- Resolves #241

## Validation
- `python -m py_compile scripts/generate-release-notes.py`
- `./scripts/run-tests.sh mgw_api.tests.test_release_notes_generator`
- `./scripts/run-tests.sh`

Stacked on #285.